### PR TITLE
Restrict WinAPI includes to implementation only (don't leak windows.h)

### DIFF
--- a/comp/windows-gui/include/qx/windows-gui/qx-taskbarbutton.h
+++ b/comp/windows-gui/include/qx/windows-gui/qx-taskbarbutton.h
@@ -5,10 +5,9 @@
 #include <QObject>
 #include <QWindow>
 
-// Windows Includes
-#define NOMINMAX
-#include "ShObjIdl_core.h"
-#undef NOMINMAX
+// Windows Forward Declarations
+struct ITaskbarList4;
+
 
 namespace Qx
 {
@@ -21,11 +20,11 @@ class TaskbarButton : public QObject
 //-Class Enums------------------------------------------------------------------------------------------------------
 public:
     enum ProgressState {
-        Hidden = TBPF_NOPROGRESS,
-        Busy = TBPF_INDETERMINATE,
-        Normal = TBPF_NORMAL,
-        Stopped = TBPF_ERROR,
-        Paused = TBPF_PAUSED,
+        Hidden,
+        Busy,
+        Normal,
+        Stopped,
+        Paused
     };
     /*! @cond */
     Q_ENUM(ProgressState); // Register for Meta-Object system

--- a/comp/windows-gui/src/qx-taskbarbutton.cpp
+++ b/comp/windows-gui/src/qx-taskbarbutton.cpp
@@ -1,6 +1,11 @@
 // Unit Includes
 #include "qx/windows-gui/qx-taskbarbutton.h"
 
+// Windows Includes
+#define NOMINMAX
+#include "ShObjIdl_core.h"
+#undef NOMINMAX
+
 // Intra-component Includes
 #include "qx/windows-gui/qx-winguievent.h"
 #include "qx-winguieventfilter_p.h"
@@ -10,6 +15,28 @@
 
 namespace Qx
 {
+
+namespace  // Anonymous namespace for effectively private (to this cpp) functions
+{
+    TBPFLAG getNativeProgressState(TaskbarButton::ProgressState ps)
+    {
+        switch(ps)
+        {
+            case TaskbarButton::ProgressState::Hidden:
+                return TBPF_NOPROGRESS;
+            case TaskbarButton::ProgressState::Busy:
+                return TBPF_INDETERMINATE;
+            case TaskbarButton::ProgressState::Normal:
+                return TBPF_NORMAL;
+            case TaskbarButton::ProgressState::Stopped:
+                return TBPF_ERROR;
+            case TaskbarButton::ProgressState::Paused:
+                return TBPF_PAUSED;
+            default:
+                return TBPF_NOPROGRESS;
+        }
+    }
+}
 
 //===============================================================================================================
 // TaskbarButton
@@ -273,7 +300,7 @@ void TaskbarButton::updateProgressIndicator()
 
     // Reinforce progress state since SetProgressValue can change it
     mTaskbarInterface->SetProgressState(getNativeWindowHandle(),
-                                        static_cast<TBPFLAG>(mProgressState));
+                                        getNativeProgressState(mProgressState));
 }
 
 //Public:

--- a/comp/windows/CMakeLists.txt
+++ b/comp/windows/CMakeLists.txt
@@ -8,12 +8,18 @@ set(COMPONENT_LIB_TYPE STATIC)
 set(COMPONENT_INCLUDE_HEADERS
     qx-common-windows.h
     qx-filedetails.h
+    qx-windefs.h
 )
 
 # Source Files
 set(COMPONENT_IMPL
     qx-common-windows.cpp
     qx-filedetails.cpp
+)
+
+# Doc Only Files
+set(COMPONENT_DOC_ONLY
+    qx-windefs.dox
 )
 
 # Links

--- a/comp/windows/include/qx/windows/qx-common-windows.h
+++ b/comp/windows/include/qx/windows/qx-common-windows.h
@@ -4,13 +4,9 @@
 // Qt Includes
 #include <QString>
 
-// Windows Includes
-#define NOMINMAX
-#include "Windows.h"
-#undef NOMINMAX
-
 // Intra-component Includes
 #include "qx/windows/qx-filedetails.h"
+#include "qx/windows/qx-windefs.h"
 
 // Extra-component Includes
 #include "qx/core/qx-genericerror.h"
@@ -22,9 +18,9 @@ namespace Qx
 struct ShortcutProperties
 {
     enum ShowMode {
-        NORMAL = SW_SHOWNORMAL,
-        MAXIMIZED = SW_SHOWMAXIMIZED,
-        MINIMIZED = SW_SHOWMINIMIZED
+        NORMAL,
+        MAXIMIZED,
+        MINIMIZED
     };
 
     QString target;

--- a/comp/windows/include/qx/windows/qx-filedetails.h
+++ b/comp/windows/include/qx/windows/qx-filedetails.h
@@ -5,10 +5,8 @@
 #include <QString>
 #include <QHash>
 
-// Windows Includes
-#define NOMINMAX
-#include "Windows.h"
-#undef NOMINMAX
+// Intra-component Includes
+#include "qx/windows/qx-windefs.h"
 
 // Extra-component Includes
 #include "qx/core/qx-versionnumber.h"

--- a/comp/windows/include/qx/windows/qx-windefs.h
+++ b/comp/windows/include/qx/windows/qx-windefs.h
@@ -1,0 +1,9 @@
+#ifndef QX_WINDEFS_H
+#define QX_WINDEFS_H
+
+typedef unsigned long DWORD;
+typedef long LONG;
+typedef LONG HRESULT;
+typedef LONG NTSTATUS;
+
+#endif // QX_WINDEFS_H

--- a/comp/windows/src/qx-common-windows.cpp
+++ b/comp/windows/src/qx-common-windows.cpp
@@ -6,6 +6,9 @@
 #include <QCoreApplication>
 
 // Windows Includes
+#define NOMINMAX
+#include "windows.h"
+#undef NOMINMAX
 #include "TlHelp32.h"
 #include "comdef.h"
 #include "ShObjIdl.h"
@@ -149,6 +152,21 @@ namespace  // Anonymous namespace for effectively private (to this cpp) function
 
         // Name is unique
         return true;
+    }
+
+    int nativeShowMode(ShortcutProperties::ShowMode showMode)
+    {
+        switch(showMode)
+        {
+            case ShortcutProperties::ShowMode::NORMAL:
+                return SW_SHOWNORMAL;
+            case ShortcutProperties::ShowMode::MAXIMIZED:
+                return SW_SHOWMAXIMIZED;
+            case ShortcutProperties::ShowMode::MINIMIZED:
+                return SW_SHOWMINIMIZED;
+            default:
+                return SW_SHOWNORMAL;
+        }
     }
 }
 
@@ -400,7 +418,7 @@ Qx::GenericError createShortcut(QString shortcutPath, ShortcutProperties sp)
                 return translateHresult(hRes);
         }
 
-        hRes = ipShellLink->SetShowCmd(sp.showMode);
+        hRes = ipShellLink->SetShowCmd(nativeShowMode(sp.showMode));
         if (FAILED(hRes))
             return translateHresult(hRes);
 

--- a/comp/windows/src/qx-filedetails.cpp
+++ b/comp/windows/src/qx-filedetails.cpp
@@ -1,6 +1,11 @@
 // Unit Includes
 #include "qx/windows/qx-filedetails.h"
 
+// Windows
+#define NOMINMAX
+#include "windows.h"
+#undef NOMINMAX
+
 // Qt Includes
 #include <QFileInfo>
 

--- a/comp/windows/src/qx-windefs.dox
+++ b/comp/windows/src/qx-windefs.dox
@@ -1,0 +1,34 @@
+/*!
+ *  @file qx-windefs.h
+ *  @ingroup qx-windows
+ *
+ *  @brief The qx-windefs header file provides a subset of Windows data types definitions.
+ *
+ *  @note This header exists largely as an implementation detail and is unlikely to be useful in
+ *  external projects.
+ *
+ *  The purpose of this header is to allow the Qx API to refer to Windows data types without polluting
+ *  user code with the entirety of windows.h and related headers.
+ *
+ *  @sa https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
+ */
+
+/*!
+ *  @typedef DWORD
+ *  An unsigned 32-bit integer
+ */
+
+/*!
+ *  @typedef @ref LONG
+ *  A signed 32-bit integer
+ */
+
+/*!
+ *  @typedef HRESULT
+ *  Same as @ref LONG
+ */
+
+/*!
+ *  @typedef NTSTATUS
+ *  Same as @ref LONG
+ */


### PR DESCRIPTION
By moving includes to .cpp and using qx-windefs.h, all references to
windows.h and related headers are contained within the libraries
implementation only, preventing global pollution in user code.