### PR TITLE
Add qx_windows.h as a less cumbersome alternative to windows.h alone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,12 @@ if(DOXYGEN_FOUND)
             "${COMPONENTS_PATH}/${component}/include"
         )
 
+        if(EXISTS "${COMPONENTS_PATH}/${component}/doc/general")
+            set(DOC_INPUT_LIST ${DOC_INPUT_LIST}
+                "${COMPONENTS_PATH}/${component}/doc/general"
+            )
+        endif()
+
         if(EXISTS "${COMPONENTS_PATH}/${component}/doc/snippets")
             set(DOC_EXAMPLE_LIST ${DOC_EXAMPLE_LIST}
                 "${COMPONENTS_PATH}/${component}/doc/snippets"

--- a/comp/windows-gui/src/qx-taskbarbutton.cpp
+++ b/comp/windows-gui/src/qx-taskbarbutton.cpp
@@ -2,9 +2,7 @@
 #include "qx/windows-gui/qx-taskbarbutton.h"
 
 // Windows Includes
-#define NOMINMAX
-#include "ShObjIdl_core.h"
-#undef NOMINMAX
+#include "qx_windows.h"
 
 // Intra-component Includes
 #include "qx/windows-gui/qx-winguievent.h"

--- a/comp/windows-gui/src/qx-winguieventfilter.cpp
+++ b/comp/windows-gui/src/qx-winguieventfilter.cpp
@@ -5,9 +5,7 @@
 #include <QGuiApplication>
 
 // Windows Includes
-#define NOMINMAX
-#include "Windows.h"
-#undef NOMINMAX
+#include "qx_windows.h"
 
 // Intra-component Includes
 #include "qx/windows-gui/qx-winguievent.h"

--- a/comp/windows/doc/general/qx_windows.dox
+++ b/comp/windows/doc/general/qx_windows.dox
@@ -1,0 +1,19 @@
+/*!
+ *  @file qx_windows.h
+ *  @ingroup qx-windows
+ *
+ *  @brief The qx_windows header file acts as a lightweight alias for windows.h.
+ *
+ *  Including this header provides access to a subset of the Win32 API that consists of the most
+ *  frequently used components, and can be used as a less cumbersome drop-in replacement for windows.h
+ *  most of the time.
+ *
+ *  It is specifically designed to avoid well-known issues that can arise when simply including
+ *  windows.h, such as non-portable definitions of @c min and @c max.
+ *
+ *  Generally, any specific Windows API headers that are not included by this one can simply be
+ *  included afterwards to keep bloat to a minimum.
+ *
+ *  @warning This header will not work if you need to use Windows GDI+ due to their reliance on
+ *  Microsoft's definition of @c min and @c max.
+ */

--- a/comp/windows/doc/windows.dox
+++ b/comp/windows/doc/windows.dox
@@ -10,4 +10,7 @@
  *  Qx Windows contains classes and functions that generally either wrap existing Win32 API functionality
  *  into a more user friendly interface, other otherwise make various programming tasks on Windows more
  *  convenient.
+ *
+ *  Not to be confused with @c <qx/windows.h>, this component also provides the header qx_windows.h as
+ *  an alternative to the standard windows.h.
  */

--- a/comp/windows/include/qx_windows.h
+++ b/comp/windows/include/qx_windows.h
@@ -1,0 +1,4 @@
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include "windows.h"
+#include "ShObjIdl_core.h"

--- a/comp/windows/src/qx-common-windows.cpp
+++ b/comp/windows/src/qx-common-windows.cpp
@@ -6,9 +6,7 @@
 #include <QCoreApplication>
 
 // Windows Includes
-#define NOMINMAX
-#include "windows.h"
-#undef NOMINMAX
+#include "qx_windows.h"
 #include "TlHelp32.h"
 #include "comdef.h"
 #include "ShObjIdl.h"

--- a/comp/windows/src/qx-filedetails.cpp
+++ b/comp/windows/src/qx-filedetails.cpp
@@ -2,9 +2,7 @@
 #include "qx/windows/qx-filedetails.h"
 
 // Windows
-#define NOMINMAX
-#include "windows.h"
-#undef NOMINMAX
+#include "qx_windows.h"
 
 // Qt Includes
 #include <QFileInfo>


### PR DESCRIPTION
Part of Windows component, can be included with <qx_windows.h>