### PR TITLE
Enable auto-detection of Qt6 prefix based dependencies (currently only documentation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,11 +98,14 @@ set(QT_FIND_COMPONENTS
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     list(APPEND LIB_COMPONENTS windows)
     list(APPEND LIB_COMPONENTS windows-gui)
+
+    set(QT_HELP_GEN_NAME "qthelpgenerator.exe")
 endif()
 
 ################# Linux Build #################
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
+    set(QT_HELP_GEN_NAME "qthelpgenerator")
 endif()
 
 #================= Top Level Build =========================
@@ -184,14 +187,14 @@ if(DOXYGEN_FOUND)
 
     # Determine Qt related doc paths
     if(NOT DEFINED QT_HELP_GEN_PATH)
-        if(EXISTS "${Qt6_PREFIX_PATH}/bin/qhelpgenerator.exe")
-            set(QT_HELP_GEN_PATH "${Qt6_PREFIX_PATH}/bin/qhelpgenerator.exe")
-            message(STATUS "Automatically configured qhelpgenerator.exe path")
+        if(EXISTS "${Qt6_PREFIX_PATH}/bin/${QT_HELP_GEN_NAME}")
+            set(QT_HELP_GEN_PATH "${Qt6_PREFIX_PATH}/bin/${QT_HELP_GEN_NAME}")
+            message(STATUS "Automatically configured qhelpgenerator path")
         else()
-            message(STATUS "Could not determine qhelpgenerator.exe path automatically.")
+            message(STATUS "Could not determine qhelpgenerator path automatically.")
         endif()
     else()
-        message(STATUS "Path of qhelpgenerator.exe set externally to: ${QT_HELP_GEN_PATH}")
+        message(STATUS "Path of qhelpgenerator set externally to: ${QT_HELP_GEN_PATH}")
     endif()
 
     if(NOT DEFINED QT_DOCS_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,17 +108,8 @@ endif()
 #================= Top Level Build =========================
 
 # Find Qt package
-find_package(Qt6 REQUIRED COMPONENTS ${QT_FIND_COMPONENTS})
-
-# Determine Qt linkage
-get_target_property(QT_CORE_TARGET_TYPE Qt6::Core TYPE)
-if(QT_CORE_TARGET_TYPE STREQUAL SHARED_LIBRARY)
-    set(QT_LINKAGE shared)
-elseif(QT_CORE_TARGET_TYPE STREQUAL STATIC_LIBRARY)
-    set(QT_LINKAGE static)
-else()
-    message(FATAL_ERROR "Qt6 Core target type has an unexpected value!")
-endif()
+include(BetterFindQt6)
+find_qt6_package(REQUIRED COMPONENTS ${QT_FIND_COMPONENTS})
 
 # Find Doxygen package
 find_package(Doxygen
@@ -191,6 +182,29 @@ if(DOXYGEN_FOUND)
         endif()
     endforeach()
 
+    # Determine Qt related doc paths
+    if(NOT DEFINED QT_HELP_GEN_PATH)
+        if(EXISTS "${Qt6_PREFIX_PATH}/bin/qhelpgenerator.exe")
+            set(QT_HELP_GEN_PATH "${Qt6_PREFIX_PATH}/bin/qhelpgenerator.exe")
+            message(STATUS "Automatically configured qhelpgenerator.exe path")
+        else()
+            message(STATUS "Could not determine qhelpgenerator.exe path automatically.")
+        endif()
+    else()
+        message(STATUS "Path of qhelpgenerator.exe set externally to: ${QT_HELP_GEN_PATH}")
+    endif()
+
+    if(NOT DEFINED QT_DOCS_DIR)
+        if(EXISTS "${Qt6_PREFIX_PATH}/doc/qtcore/qtcore.index")
+            set(QT_DOCS_DIR "${Qt6_PREFIX_PATH}/doc")
+            message(STATUS "Automatically configured Qt documentation path.")
+        else()
+            message(STATUS "Could not determine Qt documentation path automatically.")
+        endif()
+    else()
+        message(STATUS "Path of Qt documentation set externally to: ${QT_DOCS_DIR}")
+    endif()
+
     # Set Doxygen parameters
     include(${DOC_SCRIPTS_PATH}/doxyconf.cmake)
 
@@ -231,7 +245,7 @@ install(DIRECTORY ${DOC_BUILD_PATH}
 
 set(CPACK_PACKAGE_VENDOR "oblivioncth")
 set(CPACK_PACKAGE_DIRECTORY "${PACKAGE_PREFIX}")
-set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}_${PROJECT_VERSION_VERBOSE}_(Qt${Qt6_VERSION}-${QT_LINKAGE})_${CMAKE_SYSTEM_NAME}_${TARGET_ARCH}")
+set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}_${PROJECT_VERSION_VERBOSE}_(Qt${Qt6_VERSION}-${Qt6_LINKAGE})_${CMAKE_SYSTEM_NAME}_${TARGET_ARCH}")
 set(CPACK_GENERATOR "ZIP")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")

--- a/cmake/file_templates/doc_mainpage.md.in
+++ b/cmake/file_templates/doc_mainpage.md.in
@@ -82,7 +82,18 @@ The CMake project is designed to be used with multi-configuration generators suc
  - docs - Builds the Qx documentation
 
 #### Documentation:
-In order to link the documentation to Qt documentation the CMake variable **QT_DOCS_DIR** must be set to the root path that contains documentation for the Qt version you are building with. It should look something like this:
+The Qx documentation supports two optional, but highly recommended features:
+ - Linking to Qt documentation
+ - Generating a Qt Compressed Help (.qch) file for use in Qt Creator
+
+In order to enable these features, the CMake variables **QT_DOCS_DIR** and **QT_HELP_GEN_PATH** respectively must be available. Qx tries to set them automatically according to the following defaults, but these can be overridden by passing definitions for the variables on the command line.
+
+    # Optional documentation defaults
+    # Here <QT_ROOT> refers to the install directory of a given Qt build
+    QT_DOCS_DIR: <QT_ROOT>/doc
+    QT_HELP_GEN_PATH: <QT_ROOT>/bin/qhelpgenerator(.exe) # Extension only on windows
+
+If supplying **QT_DOCS_DIR** manually, it must be set to the root path that contains documentation for the Qt version you are building with. It should look something like this:
 
     doc/
     ├── config
@@ -110,12 +121,10 @@ The path for this documentation varies depending on how you obtained Qt, but is 
     # NOTE:
     # By default on Windows <QT_SOFTWARE> is C:\Program Files\Qt
     # On Linux it is often /usr/local/Qt
-    # <QT_ROOT> refers to the install directory of a given Qt build
 
+If supplying **QT_HELP_GEN_PATH** manually, it must be set to the path of the *qhelpgenerator* tool that is part of a Qt installation. Generally this is located at:
 
-In order to create a Qt Compressed Help (.qch) file of the documentation for use with Qt Creator the CMake variable **QT_HELP_GEN_PATH** must be set to the path of the *qhelpgenerator* tool that is part of a Qt installation. Generally this is located at:
-
-    <QT_ROOT>/bin/qhelpgenerator.exe
+    <QT_ROOT>/bin/qhelpgenerator(.exe)
 
 
 #### Package

--- a/cmake/module/BetterFindQt6.cmake
+++ b/cmake/module/BetterFindQt6.cmake
@@ -17,7 +17,13 @@ macro(find_qt6_package)
     endif()
 
     # Ensure install prefix is valid
-    if(NOT EXISTS "${Qt6_PREFIX_PATH}/bin/qmake.exe")
+    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+        set(__QMAKE_NAME "qmake.exe")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+        set(__QMAKE_NAME "qmake")
+    endif()
+
+    if(NOT EXISTS "${Qt6_PREFIX_PATH}/bin/${__QMAKE_NAME}")
         message(FATAL_ERROR "Qt6_PREFIX_PATH could not be determined!")
     endif()
 

--- a/cmake/module/BetterFindQt6.cmake
+++ b/cmake/module/BetterFindQt6.cmake
@@ -1,0 +1,33 @@
+macro(find_qt6_package)
+    # Find Qt normally
+    find_package(Qt6 ${ARGN})
+
+    # Determine install prefix
+    if(PACKAGE_PREFIX_DIR) # Defined by Qt6Config.cmake
+        set(Qt6_PREFIX_PATH ${PACKAGE_PREFIX_DIR})
+    else()
+        # Determine based on config script path
+        cmake_path(REMOVE_FILENAME ${Qt6_CONFIG}
+            OUTPUT_VARIABLE __QT_CONFIG_PATH
+        )
+        cmake_path(ABSOLUTE_PATH "${__QT_CONFIG_PATH}/../../../"
+            NORMALIZE
+            OUTPUT_VARIABLE Qt6_PREFIX_PATH
+        )
+    endif()
+
+    # Ensure install prefix is valid
+    if(NOT EXISTS "${Qt6_PREFIX_PATH}/bin/qmake.exe")
+        message(FATAL_ERROR "Qt6_PREFIX_PATH could not be determined!")
+    endif()
+
+    # Determine Linkage
+    get_target_property(__QT_CORE_TARGET_TYPE Qt6::Core TYPE)
+    if(__QT_CORE_TARGET_TYPE STREQUAL SHARED_LIBRARY)
+        set(Qt6_LINKAGE shared)
+    elseif(__QT_CORE_TARGET_TYPE STREQUAL STATIC_LIBRARY)
+        set(Qt6_LINKAGE static)
+    else()
+        message(FATAL_ERROR "Qt6 Core target type has an unexpected value!")
+    endif()
+endmacro()


### PR DESCRIPTION
Remove the need to specify QT_DOCS_DIR and QT_HELP_GEN_PATH if they're available in the provided Qt install at the standard locations.