### PR TITLE
Fix SyncDownloadManager documentation grouping

### DIFF
--- a/comp/network/src/qx-syncdownloadmanager.cpp
+++ b/comp/network/src/qx-syncdownloadmanager.cpp
@@ -18,7 +18,6 @@ namespace Qx
 
 /*!
  *  @class SyncDownloadManager::Report qx/network/qx-syncdownloadmanager.h
- *  @ingroup qx-network
  *
  *  @brief The SyncDownloadManager::Report class details the outcome of processing a SyncDownloadManager queue.
  *
@@ -66,6 +65,7 @@ bool SyncDownloadManager::Report::wasSuccessful() const { return mFinishStatus =
 
 /*!
  *  @class SyncDownloadManager qx/network/qx-syncdownloadmanager.h
+ *  @ingroup qx-network
  *
  *  @brief The SyncDownloadManager class is used to queue and process one or more downloads in a synchronous
  *  manner.


### PR DESCRIPTION
Sub-class SyncDownloadManager::Report was accidentally added to
Qx::Network instead of the main class.