### PR TITLE
Make library function better as an export for use in a sub-project (i.e FetchContent)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ project(Qx
     LANGUAGES CXX
     DESCRIPTION "Qt Extensions Library"
 )
-string(TOLOWER ${PROJECT_NAME} PROJ_NAME_LC)
-string(TOUPPER ${PROJECT_NAME} PROJ_NAME_UC)
+string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LC)
+string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UC)
 
 # C++
 set(CMAKE_CXX_STANDARD 20)
@@ -205,10 +205,13 @@ endif()
 
 #================= Top Level Install =======================
 
+set(TOP_LEVEL_INSTALL_COMPONENT ${PROJECT_NAME_LC})
+
 # Install Package Config
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake"
+    COMPONENT ${TOP_LEVEL_INSTALL_COMPONENT}
     DESTINATION cmake
 )
 
@@ -216,11 +219,13 @@ install(FILES
 install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
     "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
+    COMPONENT ${TOP_LEVEL_INSTALL_COMPONENT}
     DESTINATION .
 )
 
 # Install Docs if available
 install(DIRECTORY ${DOC_BUILD_PATH}
+    COMPONENT ${PROJECT_NAME_LC}_docs
     DESTINATION .
     CONFIGURATIONS Release
     OPTIONAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ project(Qx
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LC)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UC)
 
+# Check if top level
+if(${PROJECT_IS_TOP_LEVEL})
+    message(STATUS "NOTE: Qx is being configured as a top-level project")
+else()
+    set(SUB_PROJ_EXCLUDE_FROM_ALL "EXCLUDE_FROM_ALL")
+    message(STATUS "NOTE: Qx is being configured as a sub-project")
+endif()
+
 # C++
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -213,6 +221,7 @@ install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake"
     COMPONENT ${TOP_LEVEL_INSTALL_COMPONENT}
     DESTINATION cmake
+    ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
 )
 
 # Install README and LICENSE
@@ -221,6 +230,7 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
     COMPONENT ${TOP_LEVEL_INSTALL_COMPONENT}
     DESTINATION .
+    ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
 )
 
 # Install Docs if available
@@ -229,6 +239,7 @@ install(DIRECTORY ${DOC_BUILD_PATH}
     DESTINATION .
     CONFIGURATIONS Release
     OPTIONAL
+    ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
 )
 
 #====================== CPack ==============================

--- a/cmake/doc/doxyconf.cmake
+++ b/cmake/doc/doxyconf.cmake
@@ -31,7 +31,7 @@ set(DOXYGEN_IMAGE_PATH ${DOC_IMAGE_LIST})
 # Configure custom command/macro processing
 set(DOXYGEN_ALIASES
 	[[qflag{2}="@typedef \1^^<p>The \1 type is a typedef for QFlags\<\2\>. It stores an OR combination of \2 values.</p>"]]
-        "component{2}=\"@par Import:^^@code find_package(${PROJECT_NAME} REQUIRED COMPONENTS \\1)@endcode ^^@par Link:^^@code target_link_libraries(target_name ${PROJECT_NAME}::\\1)@endcode ^^@par Include:^^@code #include <${PROJ_NAME_LC}/\\2>@endcode\""
+        "component{2}=\"@par Import:^^@code find_package(${PROJECT_NAME} REQUIRED COMPONENTS \\1)@endcode ^^@par Link:^^@code target_link_libraries(target_name ${PROJECT_NAME}::\\1)@endcode ^^@par Include:^^@code #include <${PROJECT_NAME_LC}/\\2>@endcode\""
 )
 
 set(DOXYGEN_PREDEFINED

--- a/cmake/file_templates/QxComponentConfig.cmake.in
+++ b/cmake/file_templates/QxComponentConfig.cmake.in
@@ -1,21 +1,21 @@
 # Guard against multiple imports
-if(NOT DEFINED __@PROJ_NAME_UC@_@COMPONENT_NAME_UC@)
+if(NOT DEFINED __@PROJECT_NAME_UC@_@COMPONENT_NAME_UC@)
     message(VERBOSE "[@PROJECT_NAME@] Importing component: @COMPONENT_NAME@...")
-    set(__@PROJ_NAME_UC@_@COMPONENT_NAME_UC@ TRUE)
+    set(__@PROJECT_NAME_UC@_@COMPONENT_NAME_UC@ TRUE)
 
     # Inter-component dependencies (inserted when this file was configured)
-    set(__@PROJ_NAME_UC@_@COMPONENT_NAME_UC@_SIBLING_DEPENDS @COMPONENT_SIBLING_DEPENDS@)
+    set(__@PROJECT_NAME_UC@_@COMPONENT_NAME_UC@_SIBLING_DEPENDS @COMPONENT_SIBLING_DEPENDS@)
 
     # Import above dependencies first
-    foreach(sibling ${__@PROJ_NAME_UC@_@COMPONENT_NAME_UC@_SIBLING_DEPENDS})
+    foreach(sibling ${__@PROJECT_NAME_UC@_@COMPONENT_NAME_UC@_SIBLING_DEPENDS})
         message(VERBOSE "[@PROJECT_NAME@] Component @COMPONENT_NAME@ depends on ${sibling}")
         include("${CMAKE_CURRENT_LIST_DIR}/../${sibling}/@PROJECT_NAME@${sibling}Config.cmake")
     endforeach()
 
     # Qt dependencies (inserted when this file was configured)
-    set(__@PROJ_NAME_UC@_@COMPONENT_NAME_UC@_QT_DEPENDS @COMPONENT_QT_DEPENDS@)
-    if(__@PROJ_NAME_UC@_@COMPONENT_NAME_UC@_QT_DEPENDS)
-        find_dependency(Qt6 REQUIRED COMPONENTS ${__@PROJ_NAME_UC@_@COMPONENT_NAME_UC@_QT_DEPENDS})
+    set(__@PROJECT_NAME_UC@_@COMPONENT_NAME_UC@_QT_DEPENDS @COMPONENT_QT_DEPENDS@)
+    if(__@PROJECT_NAME_UC@_@COMPONENT_NAME_UC@_QT_DEPENDS)
+        find_dependency(Qt6 REQUIRED COMPONENTS ${__@PROJECT_NAME_UC@_@COMPONENT_NAME_UC@_QT_DEPENDS})
     endif()
 
     # Import component targets

--- a/cmake/file_templates/QxConfig.cmake.in
+++ b/cmake/file_templates/QxConfig.cmake.in
@@ -2,14 +2,14 @@
 include(CMakeFindDependencyMacro)
 
 # Find available Components
-file(GLOB __@PROJ_NAME_UC@_AVAILABLE_COMPONENTS
+file(GLOB __@PROJECT_NAME_UC@_AVAILABLE_COMPONENTS
     RELATIVE "${CMAKE_CURRENT_LIST_DIR}"
     "${CMAKE_CURRENT_LIST_DIR}/*/@PROJECT_NAME@*Config.cmake"
 )
 
 # Report available Components
 message(STATUS "[@PROJECT_NAME@] Available Components:")
-foreach(component_config ${__@PROJ_NAME_UC@_AVAILABLE_COMPONENTS})
+foreach(component_config ${__@PROJECT_NAME_UC@_AVAILABLE_COMPONENTS})
     message(STATUS "- ${component_config}")
 endforeach()
 
@@ -21,7 +21,7 @@ if(@PROJECT_NAME@_FIND_COMPONENTS)
     foreach(req_component ${@PROJECT_NAME@_FIND_COMPONENTS})
         set(req_component_config ${req_component}/@PROJECT_NAME@${req_component}Config.cmake)
 
-        if (";${__@PROJ_NAME_UC@_AVAILABLE_COMPONENTS};" MATCHES ";${req_component_config};")
+        if (";${__@PROJECT_NAME_UC@_AVAILABLE_COMPONENTS};" MATCHES ";${req_component_config};")
             message(STATUS "[@PROJECT_NAME@] Including matched component: ${req_component}.")
             include("${CMAKE_CURRENT_LIST_DIR}/${req_component_config}")
         elseif(@PROJECT_NAME@_FIND_REQUIRED_${req_component}})
@@ -33,7 +33,7 @@ else() # Components were not requested
     message(STATUS "[@PROJECT_NAME@] No components were requested.")
 
     # Add all components
-    foreach(component_config ${__@PROJ_NAME_UC@_AVAILABLE_COMPONENTS})
+    foreach(component_config ${__@PROJECT_NAME_UC@_AVAILABLE_COMPONENTS})
         message(STATUS "[@PROJECT_NAME@] Including available component: ${component_config}.")
         include("${CMAKE_CURRENT_LIST_DIR}/${component_config}")
     endforeach()

--- a/cmake/module/ComponentHelper.cmake
+++ b/cmake/module/ComponentHelper.cmake
@@ -10,7 +10,7 @@ macro(register_qx_component)
 
     # Name here needs to be as unique as possible for when this project is inlcuded
     # in another via FetchContent or add_subdirectory (prevent target clashes)
-    set(COMPONENT_TARGET_NAME ${PROJECT_NAME}_${COMPONENT_NAME})
+    set(COMPONENT_TARGET_NAME ${PROJECT_NAME_LC}_${COMPONENT_NAME_LC})
 
     # Make lib target
     qt_add_library(${COMPONENT_TARGET_NAME} ${COMPONENT_LIB_TYPE})
@@ -55,11 +55,11 @@ macro(register_qx_component)
     if(COMPONENT_INCLUDE_HEADERS)
         # Build pathed include file list
         foreach(api_header ${COMPONENT_INCLUDE_HEADERS})
-            set(pathed_api_headers ${pathed_api_headers} "include/${PROJ_NAME_LC}/${COMPONENT_NAME_LC}/${api_header}")
+            set(pathed_api_headers ${pathed_api_headers} "include/${PROJECT_NAME_LC}/${COMPONENT_NAME_LC}/${api_header}")
         endforeach()
 
         # Group include files with their parent directories stripped
-        source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJ_NAME_LC}/${COMPONENT_NAME_LC}"
+        source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME_LC}/${COMPONENT_NAME_LC}"
             PREFIX "Include Files"
             FILES ${pathed_api_headers}
         )
@@ -100,13 +100,13 @@ macro(register_qx_component)
 
     # Generate include statements
     foreach(api_header ${COMPONENT_INCLUDE_HEADERS})
-        set(PRIM_COMP_HEADER_INCLUDES "${PRIM_COMP_HEADER_INCLUDES}#include <${PROJ_NAME_LC}/${COMPONENT_NAME_LC}/${api_header}>\n")
+        set(PRIM_COMP_HEADER_INCLUDES "${PRIM_COMP_HEADER_INCLUDES}#include <${PROJECT_NAME_LC}/${COMPONENT_NAME_LC}/${api_header}>\n")
     endforeach()
 
     # Copy template with modifications
     configure_file(
         "${FILE_TEMPLATES_PATH}/primary_component_header.h.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJ_NAME_LC}/${COMPONENT_NAME_LC}.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME_LC}/${COMPONENT_NAME_LC}.h"
         @ONLY
         NEWLINE_STYLE UNIX
     )
@@ -131,23 +131,26 @@ macro(register_qx_component)
 
     # Install component lib
     install(TARGETS ${COMPONENT_TARGET_NAME}
+        COMPONENT ${COMPONENT_TARGET_NAME}
         EXPORT ${COMPONENT_NAME}Targets
-        COMPONENT ${COMPONENT_NAME}
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin # For potential future shared version
     )
 
     # Install public headers
-    install(DIRECTORY include/${PROJ_NAME_LC}
+    install(DIRECTORY include/${PROJECT_NAME_LC}
+        COMPONENT ${COMPONENT_TARGET_NAME}
         DESTINATION "include/${COMPONENT_NAME_LC}"
     )
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJ_NAME_LC}/${COMPONENT_NAME_LC}.h"
-        DESTINATION "${HEADER_INSTALL_SUFFIX}/${COMPONENT_NAME_LC}/${PROJ_NAME_LC}"
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME_LC}/${COMPONENT_NAME_LC}.h"
+        COMPONENT ${COMPONENT_TARGET_NAME}
+        DESTINATION "${HEADER_INSTALL_SUFFIX}/${COMPONENT_NAME_LC}/${PROJECT_NAME_LC}"
     )
 
     # Install package target export
     install(EXPORT ${COMPONENT_NAME}Targets
+        COMPONENT ${COMPONENT_TARGET_NAME}
         FILE "${PROJECT_NAME}${COMPONENT_NAME}Targets.cmake"
         NAMESPACE ${PROJECT_NAME}::
         DESTINATION cmake/${COMPONENT_NAME}
@@ -156,6 +159,7 @@ macro(register_qx_component)
     # Install package config
     install(FILES
         "${PROJECT_BINARY_DIR}/cmake/${COMPONENT_NAME}/${PROJECT_NAME}${COMPONENT_NAME}Config.cmake"
+        COMPONENT ${COMPONENT_TARGET_NAME}
         DESTINATION cmake/${COMPONENT_NAME}
     )
 

--- a/cmake/module/ComponentHelper.cmake
+++ b/cmake/module/ComponentHelper.cmake
@@ -136,16 +136,19 @@ macro(register_qx_component)
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin # For potential future shared version
+        ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
     )
 
     # Install public headers
     install(DIRECTORY include/${PROJECT_NAME_LC}
         COMPONENT ${COMPONENT_TARGET_NAME}
         DESTINATION "include/${COMPONENT_NAME_LC}"
+        ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
     )
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME_LC}/${COMPONENT_NAME_LC}.h"
         COMPONENT ${COMPONENT_TARGET_NAME}
         DESTINATION "${HEADER_INSTALL_SUFFIX}/${COMPONENT_NAME_LC}/${PROJECT_NAME_LC}"
+        ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
     )
 
     # Install package target export
@@ -154,6 +157,7 @@ macro(register_qx_component)
         FILE "${PROJECT_NAME}${COMPONENT_NAME}Targets.cmake"
         NAMESPACE ${PROJECT_NAME}::
         DESTINATION cmake/${COMPONENT_NAME}
+        ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
     )
 
     # Install package config
@@ -161,6 +165,7 @@ macro(register_qx_component)
         "${PROJECT_BINARY_DIR}/cmake/${COMPONENT_NAME}/${PROJECT_NAME}${COMPONENT_NAME}Config.cmake"
         COMPONENT ${COMPONENT_TARGET_NAME}
         DESTINATION cmake/${COMPONENT_NAME}
+        ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
     )
 
     #========Export For In-tree Builds =================

--- a/cmake/module/ComponentHelper.cmake
+++ b/cmake/module/ComponentHelper.cmake
@@ -133,10 +133,10 @@ macro(register_qx_component)
     install(TARGETS ${COMPONENT_TARGET_NAME}
         COMPONENT ${COMPONENT_TARGET_NAME}
         EXPORT ${COMPONENT_NAME}Targets
+        ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin # For potential future shared version
-        ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
     )
 
     # Install public headers

--- a/cmake/module/ComponentHelper.cmake
+++ b/cmake/module/ComponentHelper.cmake
@@ -8,12 +8,15 @@ macro(register_qx_component)
     string_to_proper_case(${COMPONENT_NAME_LC} COMPONENT_NAME)
     create_header_guard(${PROJECT_NAME} ${COMPONENT_NAME} COMPONENT_HEADER_GUARD)
 
-    set(COMPONENT_TARGET_NAME ${COMPONENT_NAME})
+    # Name here needs to be as unique as possible for when this project is inlcuded
+    # in another via FetchContent or add_subdirectory (prevent target clashes)
+    set(COMPONENT_TARGET_NAME ${PROJECT_NAME}_${COMPONENT_NAME})
 
     # Make lib target
     qt_add_library(${COMPONENT_TARGET_NAME} ${COMPONENT_LIB_TYPE})
 
-    # Make alias target so target can be referred to with its export namespace
+    # Make alias target so target can be referred to with its friendly
+    # export name both internally and when part of another build tree
     add_library(${PROJECT_NAME}::${COMPONENT_NAME} ALIAS ${COMPONENT_TARGET_NAME})
 
     #================= Build ==========================
@@ -121,6 +124,7 @@ macro(register_qx_component)
         VERSION ${PROJECT_VERSION}
         OUTPUT_NAME "${PROJECT_NAME}-${COMPONENT_NAME}"
         DEBUG_POSTFIX "d"
+        EXPORT_NAME "${COMPONENT_NAME}"
     )
 
     #================= Install ==========================


### PR DESCRIPTION
- Ensure that target names are reasonably unique, while having suitable aliases and export names such that the friendly names can be used transparently by a consumer
- Ensure every install command belongs to a component (no 'Unspecified' component)
- Automatically use "EXCLUDE_FROM_ALL" in all install commands if the project is not top level