### PR TITLE
Fix qx-io findStringInFile() and fileContainsString()

### DIFF
--- a/comp/io/src/qx-common-io.cpp
+++ b/comp/io/src/qx-common-io.cpp
@@ -484,7 +484,7 @@ IoOpReport findStringInFile(QList<TextPos>& returnBuffer, QFile& textFile, const
     {
         fileTextStream >> currentChar;
 
-        if(Char::compare(currentChar, *queryIt, query.caseSensitivity()))
+        if(Char::compare(currentChar, *queryIt, query.caseSensitivity()) == 0)
         {
             if(possibleMatch.isNull())
                 possibleMatch = currentPos;


### PR DESCRIPTION
These rely on Char::comapre which was changed to make a lexical comparison; therefore checking for a returned match needed to be changed from simply if(...) to if (... == 0)