### PR TITLE
Add qxDelete: Calls 'delete' on pointer and then sets it to null

### DIFF
--- a/comp/utility/include/qx/utility/qx-helpers.h
+++ b/comp/utility/include/qx/utility/qx-helpers.h
@@ -11,4 +11,11 @@ const T qxAsConst(T&& t) { return std::move(t); }
 template <typename T>
 typename std::add_const<T>::type qxAsConst(T& t) { return qAsConst(t); }
 
+template <typename T>
+void qxDelete(T*& pointer)
+{
+    delete pointer;
+    pointer = nullptr;
+}
+
 #endif // QX_HELPERS_H

--- a/comp/utility/src/qx-helpers.dox
+++ b/comp/utility/src/qx-helpers.dox
@@ -25,3 +25,10 @@
  *  lvalues and rvalues, instead of having to employ mixed usage of qxAsConst() and
  *  qAsConst().
  */
+
+
+/*!
+ *  @fn template <typename T> void qxDelete(T*& pointer)
+ *
+ *  Calls @c delete on @a pointer and then sets it to @c nullptr .
+ */


### PR DESCRIPTION
Convenient one-liner for when a there exists the possibility of needing to check if a pointer's object was deleted previously.