### PR TITLE
Add Json::findAllValues, recursively get all values matching a key

### DIFF
--- a/comp/core/CMakeLists.txt
+++ b/comp/core/CMakeLists.txt
@@ -25,6 +25,9 @@ set(COMPONENT_INCLUDE_HEADERS
     qx-string.h
     qx-traverser.h
 )
+set(COMPONENT_PRIVATE_HEADERS
+    qx-json_p.h
+)
 
 # Source Files
 set(COMPONENT_IMPL
@@ -34,6 +37,7 @@ set(COMPONENT_IMPL
     qx-genericerror.cpp
     qx-integrity.cpp
     qx-json.cpp
+    qx-json_p.cpp
     qx-versionnumber.cpp
     qx-string.cpp
 )

--- a/comp/core/include/qx/core/qx-json.h
+++ b/comp/core/include/qx/core/qx-json.h
@@ -29,11 +29,11 @@ private:
 
 //-Class Functions-----------------------------------------------------------------------------------------------
 public:
-    static Qx::GenericError checkedKeyRetrieval(bool& valueBuffer, QJsonObject jObject, QString key);
-    static Qx::GenericError checkedKeyRetrieval(double& valueBuffer, QJsonObject jObject, QString key);
-    static Qx::GenericError checkedKeyRetrieval(QString& valueBuffer, QJsonObject jObject, QString key);
-    static Qx::GenericError checkedKeyRetrieval(QJsonArray& valueBuffer, QJsonObject jObject, QString key);
-    static Qx::GenericError checkedKeyRetrieval(QJsonObject& valueBuffer, QJsonObject jObject, QString key);
+    static Qx::GenericError checkedKeyRetrieval(bool& valueBuffer, QJsonObject jObject, const QString& key);
+    static Qx::GenericError checkedKeyRetrieval(double& valueBuffer, QJsonObject jObject, const QString& key);
+    static Qx::GenericError checkedKeyRetrieval(QString& valueBuffer, QJsonObject jObject, const QString& key);
+    static Qx::GenericError checkedKeyRetrieval(QJsonArray& valueBuffer, QJsonObject jObject, const QString& key);
+    static Qx::GenericError checkedKeyRetrieval(QJsonObject& valueBuffer, QJsonObject jObject, const QString& key);
 };	
 
 }

--- a/comp/core/include/qx/core/qx-json.h
+++ b/comp/core/include/qx/core/qx-json.h
@@ -3,6 +3,7 @@
 
 // Qt Includes
 #include <QString>
+#include <QJsonValueRef>
 
 // Intra-component Includes
 #include "qx/core/qx-genericerror.h"
@@ -34,6 +35,8 @@ public:
     static Qx::GenericError checkedKeyRetrieval(QString& valueBuffer, QJsonObject jObject, const QString& key);
     static Qx::GenericError checkedKeyRetrieval(QJsonArray& valueBuffer, QJsonObject jObject, const QString& key);
     static Qx::GenericError checkedKeyRetrieval(QJsonObject& valueBuffer, QJsonObject jObject, const QString& key);
+
+    static QList<QJsonValue> findAllValues(const QJsonValue& rootValue, const QString& key);
 };	
 
 }

--- a/comp/core/src/qx-json.cpp
+++ b/comp/core/src/qx-json.cpp
@@ -1,5 +1,6 @@
 // Unit Includes
 #include "qx/core/qx-json.h"
+#include "qx-json_p.h"
 
 // Qt Includes
 #include <QJsonObject>
@@ -148,6 +149,20 @@ GenericError Json::checkedKeyRetrieval(QJsonObject& valueBuffer, QJsonObject jOb
         valueBuffer = potentialObject.toObject();
 
     return GenericError();
+}
+
+/*!
+ *  Recursively searches @a rootValue for @a key and returns the associated value for
+ *  all matches as a list, or an empty list if the key was not found.
+ *
+ *  If @a rootValue is of any type other than QJsonValue::Array or QJsonValue::Object
+ *  then returned list will always be empty.
+ */
+QList<QJsonValue> Json::findAllValues(const QJsonValue& rootValue, const QString& key)
+{
+    QList<QJsonValue> hits;
+    recursiveValueFinder(hits, rootValue, key);
+    return hits;
 }
 
 }

--- a/comp/core/src/qx-json.cpp
+++ b/comp/core/src/qx-json.cpp
@@ -39,7 +39,7 @@ namespace Qx
  *
  *  @a valueBuffer is set to @c false in the event of an error.
  */
-GenericError Json::checkedKeyRetrieval(bool& valueBuffer, QJsonObject jObject, QString key)
+GenericError Json::checkedKeyRetrieval(bool& valueBuffer, QJsonObject jObject, const QString& key)
 {
     // Reset buffer
     valueBuffer = false;
@@ -62,7 +62,7 @@ GenericError Json::checkedKeyRetrieval(bool& valueBuffer, QJsonObject jObject, Q
  *
  *  @a valueBuffer is set to zero in the event of an error.
  */
-GenericError Json::checkedKeyRetrieval(double& valueBuffer, QJsonObject jObject, QString key)
+GenericError Json::checkedKeyRetrieval(double& valueBuffer, QJsonObject jObject, const QString& key)
 {
     // Reset buffer
     valueBuffer = 0.0;
@@ -85,7 +85,7 @@ GenericError Json::checkedKeyRetrieval(double& valueBuffer, QJsonObject jObject,
  *
  *  @a valueBuffer is set to a null string in the event of an error.
  */
-GenericError Json::checkedKeyRetrieval(QString& valueBuffer, QJsonObject jObject, QString key)
+GenericError Json::checkedKeyRetrieval(QString& valueBuffer, QJsonObject jObject, const QString& key)
 {
     // Reset buffer
     valueBuffer = QString();
@@ -108,7 +108,7 @@ GenericError Json::checkedKeyRetrieval(QString& valueBuffer, QJsonObject jObject
  *
  *  @a valueBuffer is set to an empty JSON array in the event of an error.
  */
-GenericError Json:: checkedKeyRetrieval(QJsonArray& valueBuffer, QJsonObject jObject, QString key)
+GenericError Json:: checkedKeyRetrieval(QJsonArray& valueBuffer, QJsonObject jObject, const QString& key)
 {
     // Reset buffer
     valueBuffer = QJsonArray();
@@ -132,7 +132,7 @@ GenericError Json:: checkedKeyRetrieval(QJsonArray& valueBuffer, QJsonObject jOb
  *
  *  @a valueBuffer is set to an empty JSON object in the event of an error.
  */
-GenericError Json::checkedKeyRetrieval(QJsonObject& valueBuffer, QJsonObject jObject, QString key)
+GenericError Json::checkedKeyRetrieval(QJsonObject& valueBuffer, QJsonObject jObject, const QString& key)
 {
     // Reset buffer
     valueBuffer = QJsonObject();

--- a/comp/core/src/qx-json_p.cpp
+++ b/comp/core/src/qx-json_p.cpp
@@ -1,0 +1,34 @@
+// Unit Includes
+#include "qx-json_p.h"
+
+// Qt Includes
+#include <QJsonObject>
+#include <QJsonArray>
+
+namespace Qx
+{
+/*! @cond */
+
+void recursiveValueFinder(QList<QJsonValue>& hits, QJsonValue currentValue, const QString& key)
+{
+    if(currentValue.isObject())
+    {
+        QJsonObject obj = currentValue.toObject();
+        for(auto i = obj.constBegin(); i != obj.constEnd(); i++)
+        {
+            if(i.key() == key)
+                hits.append(*i);
+
+            recursiveValueFinder(hits, *i, key);
+        }
+    }
+    else if(currentValue.isArray())
+    {
+        QJsonArray array = currentValue.toArray();
+        for(auto i = array.constBegin(); i != array.constEnd(); i++)
+            recursiveValueFinder(hits, *i, key);
+    }
+}
+
+/*! @endcond */
+}

--- a/comp/core/src/qx-json_p.h
+++ b/comp/core/src/qx-json_p.h
@@ -1,0 +1,17 @@
+#ifndef QX_JSON_P_H
+#define QX_JSON_P_H
+
+// Qt Includes
+#include <QJsonValueRef>
+
+namespace Qx
+{
+/*! @cond */
+
+//-Component Private Functions--------------------------------------------------------------------
+void recursiveValueFinder(QList<QJsonValue>& hits, QJsonValue currentValue, const QString& key);
+
+/*! @endcond */
+}
+
+#endif // QX_JSON_P_H


### PR DESCRIPTION
/*!
 *  Recursively searches @a rootValue for @a key and returns the associated value for
 *  all matches as a list, or an empty list if the key was not found.
 *
 *  If @a rootValue is of any type other than QJsonValue::Array or QJsonValue::Object
 *  then returned list will always be empty.
 */
QList<QJsonValue> Json::findAllValues(const QJsonValue& rootValue, const QString& key);