### PR TITLE
Add component scalers to Cumulation

### DIFF
--- a/comp/core/include/qx/core/qx-cumulation.h
+++ b/comp/core/include/qx/core/qx-cumulation.h
@@ -37,7 +37,7 @@ private:
         requires std::floating_point<N>
     N sMean() const
     {
-        return !mComponents.isEmpty() ? static_cast<double>(mTotal)/mComponents.count() : 0;
+        return !mComponents.isEmpty() ? mTotal/mComponents.count() : 0;
     }
 
 public:

--- a/comp/core/src/qx-cumulation.dox
+++ b/comp/core/src/qx-cumulation.dox
@@ -12,8 +12,11 @@ namespace Qx
  *  independently.
  *
  *  A cumulation is a collection of key-value pairs (where V is any arithmetic type) with which the sum of all
- *  contained values is always known, and any individual value can added, removed, or updated through its
+ *  contained values is always known, and any individual value can be added, removed, or updated through its
  *  corresponding key.
+ *
+ *  Additionally, a cumulation can have optional scalers applied to its components in order to differently
+ *  weight their individual effect on the total.
  *
  *  This is generally useful for keeping a running total, but when a previously added value may need to be
  *  revised later, such as when tracking the overall progress of multiple downloads from a server using their
@@ -31,22 +34,43 @@ namespace Qx
 //-Class Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::clear()
+ *  @fn template <typename K, typename V> void Cumulation<K, V>::insert(K component, V value, V scaler = 1)
  *
- *  Removes all keys/values from the cumulation, resulting in a total of zero.
- */
-
-/*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::remove(K component)
+ *  Inserts a new component with key @a component, value @a value, and scaler @a scaler.
  *
- *  Removes the value associated with the key @a component from the cumulation.
+ *  If there is already a component with the same key, that component's value and scaler are replaced with
+ *  @a value and @a scaler respectively.
  */
 
 /*!
  *  @fn template <typename K, typename V> void Cumulation<K, V>::setValue(K component, V value)
  *
- *  Sets the value of @a component to @a value. The component will be added to the cumulation if it did not
- *  already contain it.
+ *  Sets the value of @a component to @a value.
+ *
+ *  If the cumulation does not contain the specified component, this method does nothing.
+ */
+
+/*!
+ *  @fn template <typename K, typename V> void Cumulation<K, V>::setScaler(K component, V scaler)
+ *
+ *  Sets the scaler of @a component to @a scaler.
+ *
+ *  The amount that a component contributes to a cumulation's total is its value multiplied
+ *  by its scaler.
+ *
+ *  If the cumulation does not contain the specified component, this method does nothing.
+ */
+
+/*!
+ *  @fn template <typename K, typename V> void Cumulation<K, V>::remove(K component)
+ *
+ *  Removes the value associated with the key @a component from the cumulation, if it exists.
+ */
+
+/*!
+ *  @fn template <typename K, typename V> void Cumulation<K, V>::clear()
+ *
+ *  Removes all keys/values from the cumulation, resulting in a total of zero.
  */
 
 /*!
@@ -86,7 +110,7 @@ namespace Qx
  *  Returns the current mean of the cumulation, which is the sum of all its component values divided the
  *  number of components, or zero if the cumulation is empty.
  *
- *  If
+ *  If @a V is an integral type, the result is rounded to the nearest integer.
  */
 
 }


### PR DESCRIPTION
Allows setting scalers for each component within a cumulation (defaults to 1). 

These can be used to add effective 'weights' to each component.

Each component contributes to the total by means of: `component_value * component_scaler`