### PR TITLE
Add GroupedProgressManager and ProgressGroup for easy weighted progress calculation

### DIFF
--- a/comp/core/CMakeLists.txt
+++ b/comp/core/CMakeLists.txt
@@ -15,11 +15,13 @@ set(COMPONENT_INCLUDE_HEADERS
     qx-datetime.h
     qx-freeindextracker.h
     qx-genericerror.h
+    qx-groupedprogressmanager.h
     qx-index.h
     qx-integrity.h
     qx-iostream.h
     qx-json.h
     qx-list.h
+    qx-progressgroup.h
     qx-versionnumber.h
     qx-regularexpression.h
     qx-string.h
@@ -35,9 +37,11 @@ set(COMPONENT_IMPL
     qx-char.cpp
     qx-datetime.cpp
     qx-genericerror.cpp
+    qx-groupedprogressmanager.cpp
     qx-integrity.cpp
     qx-json.cpp
     qx-json_p.cpp
+    qx-progressgroup.cpp
     qx-versionnumber.cpp
     qx-string.cpp
 )

--- a/comp/core/doc/snippets/qx-groupedprogressmanager.cpp
+++ b/comp/core/doc/snippets/qx-groupedprogressmanager.cpp
@@ -1,0 +1,15 @@
+//! [0]
+Qx::GroupedProgressManager gpm();
+
+Qx::ProgressGroup* fileGroup = gpm.addGroup("File Copies");
+fileGroup.setMaximum(100);
+fileGroup.setValue(50); // 50% completion of "File Copies"
+fileGroup.setWeight(3);
+
+Qx::ProgressGroup* coolGroup = gpm.addGroup("Cool Stuff");
+fileGroup.setMaximum(100);
+fileGroup.setValue(0); // 0% completion of "Cool Stuff"
+fileGroup.setWeight(7);
+
+quint64 overallProgress = gpm.value(); // overallProgress = 15
+//! [0]

--- a/comp/core/include/qx/core/qx-groupedprogressmanager.h
+++ b/comp/core/include/qx/core/qx-groupedprogressmanager.h
@@ -46,8 +46,8 @@ public:
     ProgressGroup* group(const QString& name);
     void removeGroup(const QString& name);
 
-    quint64 value();
-    quint64 maximum();
+    quint64 value() const;
+    quint64 maximum() const;
 
 //-Slots------------------------------------------------------------------------------------------------------------
 private slots:

--- a/comp/core/include/qx/core/qx-groupedprogressmanager.h
+++ b/comp/core/include/qx/core/qx-groupedprogressmanager.h
@@ -1,0 +1,65 @@
+#ifndef QX_GROUPEDPROGRESSMANAGER_H
+#define QX_GROUPEDPROGRESSMANAGER_H
+
+// Qt Includes
+#include <QObject>
+#include <QHash>
+
+// Intra-component Includes
+#include "qx/core/qx-progressgroup.h"
+
+namespace Qx
+{
+
+class GroupedProgressManager : public QObject
+{
+//-QObject Macro (Required for all QObject Derived Classes)-----------------------------------------------------------
+    Q_OBJECT
+
+//-Class Members---------------------------------------------------------------------------------------------
+private:
+    static const quint64 UNIFIED_MAXIMUM = 100;
+
+//-Instance Properties-------------------------------------------------------------------------------------------------------
+private:
+    Q_PROPERTY(quint64 value READ value NOTIFY valueChanged);
+    Q_PROPERTY(quint64 maximum READ maximum CONSTANT);
+
+//-Instance Members------------------------------------------------------------------------------------------
+private:
+    quint64 mCurrentValue;
+    QHash<QString, ProgressGroup*> mGroups;
+    QHash<QString, quint64> mRelativePortions;
+
+//-Constructor----------------------------------------------------------------------------------------------
+public:
+    explicit GroupedProgressManager(QObject* parent = nullptr);
+
+//-Instance Functions----------------------------------------------------------------------------------------------
+private:
+    void updateRelativePortions();
+    void updateValue();
+
+public:
+    void addGroup(ProgressGroup* progressGroup);
+    ProgressGroup* addGroup(const QString& name);
+    ProgressGroup* group(const QString& name);
+    void removeGroup(const QString& name);
+
+    quint64 value();
+    quint64 maximum();
+
+//-Slots------------------------------------------------------------------------------------------------------------
+private slots:
+    void childValueChanged();
+    void childMaximumChanged();
+    void childWeightChanged();
+
+//-Signals------------------------------------------------------------------------------------------------------------
+signals:
+    void valueChanged(quint64 value);
+};
+
+}
+
+#endif // QX_GROUPEDPROGRESSMANAGER_H

--- a/comp/core/include/qx/core/qx-progressgroup.h
+++ b/comp/core/include/qx/core/qx-progressgroup.h
@@ -1,0 +1,78 @@
+#ifndef QX_PROGRESSGROUP_H
+#define QX_PROGRESSGROUP_H
+
+// Qt Includes
+#include <QObject>
+#include <QString>
+#include <QProperty>
+
+namespace Qx
+{
+
+class ProgressGroup : public QObject
+{
+//-QObject Macro (Required for all QObject Derived Classes)-----------------------------------------------------------
+    Q_OBJECT
+
+//-Instance Properties-------------------------------------------------------------------------------------------------------
+private:
+    Q_PROPERTY(QString name READ name CONSTANT);
+    Q_PROPERTY(quint64 value READ value WRITE setValue NOTIFY valueChanged);
+    Q_PROPERTY(quint64 maximum READ maximum WRITE setMaximum NOTIFY maximumChanged);
+    Q_PROPERTY(quint64 weight READ weight WRITE setWeight NOTIFY weightChanged);
+    Q_PROPERTY(quint64 proportionComplete READ proportionComplete NOTIFY proportionCompleteChanged);
+
+//-Instance Members------------------------------------------------------------------------------------------
+private:
+    /* For mProportion, could just use an update function that is either called directly in settings, or connect the
+     * changed signals to the update function, but felt like trying out QProperty (Qt Bindable Properties) here. The
+     * reason it's not a QObjectBindableProperty is because in this case we only want the internal member variable to
+     * be bindable, and not the exposed Q_PROPERTY (yes the naming they chose is confusing). From the outside, it should
+     * still look like a normal variable.
+     */
+    QString mName;
+    QProperty<quint64> mValue;
+    QProperty<quint64> mMaximum;
+    quint64 mWeight;
+    QProperty<double> mProportion; // Pre-calculated and stored to save cycles in GroupedProgressManager
+    QPropertyNotifier mProportionNotifier; // Have to store this or else the assigned notify functor will be removed
+
+//-Constructor----------------------------------------------------------------------------------------------
+public:
+    explicit ProgressGroup(QString name, QObject* parent = nullptr);
+
+//-Instance Functions----------------------------------------------------------------------------------------------
+public:
+    QString name() const;
+    quint64 value() const;
+    quint64 maximum() const;
+    quint64 weight() const;
+    double proportionComplete() const;
+
+    void incrementValue();
+    void decrementValue();
+    void incrementMaximum();
+    void decrementMaximum();
+    void increaseValue(quint64 amount);
+    void decreaseValue(quint64 amount);
+    void increaseMaximum(quint64 amount);
+    void decreaseMaximum(quint64 amount);
+
+//-Slots------------------------------------------------------------------------------------------------------------
+public slots:
+    void reset();
+    void setValue(quint64 value);
+    void setMaximum(quint64 maximum);
+    void setWeight(quint64 weight);
+
+//-Signals------------------------------------------------------------------------------------------------------------
+signals:
+    void valueChanged(quint64 value);
+    void maximumChanged(quint64 maximum);
+    void weightChanged(quint64 weight);
+    void proportionCompleteChanged(double proportion);
+};
+
+}
+
+#endif // QX_PROGRESSGROUP_H

--- a/comp/core/src/qx-groupedprogressmanager.cpp
+++ b/comp/core/src/qx-groupedprogressmanager.cpp
@@ -160,7 +160,7 @@ void GroupedProgressManager::removeGroup(const QString& name)
 /*!
  *  Returns the current value of the manager.
  */
-quint64 GroupedProgressManager::value() { return mCurrentValue; }
+quint64 GroupedProgressManager::value() const { return mCurrentValue; }
 
 /*!
  *  Returns the maximum value of the manager.
@@ -168,7 +168,7 @@ quint64 GroupedProgressManager::value() { return mCurrentValue; }
  *  This function will always return @c 100, and exists as a convenience method so that
  *  user code does not need to remember this.
  */
-quint64 GroupedProgressManager::maximum() { return UNIFIED_MAXIMUM; }
+quint64 GroupedProgressManager::maximum() const { return UNIFIED_MAXIMUM; }
 
 //-Slots------------------------------------------------------------------------------------------------------------
 //Private:

--- a/comp/core/src/qx-groupedprogressmanager.cpp
+++ b/comp/core/src/qx-groupedprogressmanager.cpp
@@ -95,6 +95,7 @@ void GroupedProgressManager::updateValue()
 
 //Public:
 /*!
+ *  @overload
  *  Adds progress group @a progressGroup to the manager.
  *
  *  If a group with the same name is already present, it will be replaced.

--- a/comp/core/src/qx-groupedprogressmanager.cpp
+++ b/comp/core/src/qx-groupedprogressmanager.cpp
@@ -1,0 +1,196 @@
+// Unit Includes
+#include "qx/core/qx-groupedprogressmanager.h"
+
+namespace Qx
+{
+
+//===============================================================================================================
+// GroupedProgressManager
+//===============================================================================================================
+
+/*!
+ *  @class GroupedProgressManager
+ *  @ingroup qx-core
+ *
+ *  @brief The GroupedProgressManager class produces an overall progress value from a collection of progress
+ *  groups.
+ *
+ *  A GroupedProgressManager is used to convert the relative percent completion of an arbitrary number of
+ *  progress groups into a total completion value in accordance with their weights.
+ *
+ *  The weighting of each progress group can be used to limit a group's contribution to overall progress to a
+ *  certain proportion, regardless of that individual group's number of steps.
+ *
+ *  @snippet qx-groupedprogressmanager.cpp 0
+ *
+ *  The above example shows how even though the progress group "File Copies" is 50% complete, the progress
+ *  reported by the grouped progress manager is only 15%, because the weighting of both groups dictates that
+ *  "File Copies" only accounts for `3/(7 + 3) = 0.3` (or 30%) of overall progress.
+ *
+ *  A grouped progress manager always reports overall progress as a value from @c 0 to @c 100.
+ *
+ *  @sa ProgressGroup, QProgressBar
+ */
+
+//-Class Properties-----------------------------------------------------------------------------------------------
+//Private:
+/*!
+ *  @property GroupedProgressManager::value
+ *  @brief The current value of the grouped progress manager.
+ *
+ *  This value will always be between @c 0 and @c 100.
+ *
+ *  The default is @c 0.
+ */
+
+/*!
+*  @property GroupedProgressManager::maximum
+*  @brief The maximum value of the grouped progress manager.
+*
+*  This value is always 100.
+*/
+
+//-Constructor----------------------------------------------------------------------------------------------
+//Public:
+
+/*!
+ *  Constructs a GroupedProgressManager with the specified @a parent.
+ */
+GroupedProgressManager::GroupedProgressManager(QObject* parent) :
+    QObject(parent),
+    mCurrentValue(0)
+{}
+
+//-Instance Functions----------------------------------------------------------------------------------------------
+//Private:
+void GroupedProgressManager::updateRelativePortions()
+{
+    QHash<QString, ProgressGroup*>::const_iterator i;
+
+    // Get weight sum
+    double weightSum = 0;
+    for(i = mGroups.constBegin(); i != mGroups.constEnd(); i++)
+        weightSum += i.value()->weight();
+
+    // Assign portions
+    for(i = mGroups.constBegin(); i != mGroups.constEnd(); i++)
+        mRelativePortions[i.key()] = std::round((i.value()->weight()/weightSum) * UNIFIED_MAXIMUM);
+}
+
+void GroupedProgressManager::updateValue()
+{
+    quint64 newValue = 0;
+
+    // Add effective value of each group (use floor to avoid reporting 100% until its truly 100%)
+    QHash<QString, ProgressGroup*>::const_iterator i;
+    for(i = mGroups.constBegin(); i != mGroups.constEnd(); i++)
+        newValue += std::floor(i.value()->proportionComplete() * mRelativePortions[i.key()]);
+
+    if(newValue != mCurrentValue)
+    {
+        mCurrentValue = newValue;
+        emit valueChanged(mCurrentValue);
+    }
+}
+
+//Public:
+/*!
+ *  Adds progress group @a progressGroup to the manager.
+ *
+ *  If a group with the same name is already present, it will be replaced.
+ */
+void GroupedProgressManager::addGroup(ProgressGroup* progressGroup)
+{
+    if(!progressGroup)
+        return;
+
+    // Adopt child
+    progressGroup->setParent(this);
+
+    // Add to ledger (or replace)
+    mGroups.insert(progressGroup->name(), progressGroup);
+
+    // Connect signals
+    connect(progressGroup, &ProgressGroup::valueChanged, this, &GroupedProgressManager::childValueChanged);
+    connect(progressGroup, &ProgressGroup::maximumChanged, this, &GroupedProgressManager::childMaximumChanged);
+    connect(progressGroup, &ProgressGroup::weightChanged, this, &GroupedProgressManager::childWeightChanged);
+
+    // Update values
+    updateRelativePortions();
+    updateValue();
+}
+
+/*!
+ *  Adds a new progress group with the given @a name to the manager.
+ *
+ *  If a group with that name already exists, it will be replaced.
+ */
+ProgressGroup* GroupedProgressManager::addGroup(const QString& name)
+{
+    ProgressGroup* pg = new ProgressGroup(name);
+    addGroup(pg);
+    return pg;
+}
+
+/*!
+ *  Returns a pointer to the progress group with the given @a name, or
+ *  @c nullptr if it does not exist within the manager.
+ */
+ProgressGroup* GroupedProgressManager::group(const QString& name)
+{
+    if(mGroups.contains(name))
+        return mGroups[name];
+    else
+        return nullptr;
+}
+
+/*!
+ *  Removes the group named @a name from the manager, if present.
+ */
+void GroupedProgressManager::removeGroup(const QString& name)
+{
+    if(mGroups.contains(name))
+    {
+        ProgressGroup* pg = mGroups.take(name);
+        pg->deleteLater();
+        mRelativePortions.remove(name);
+    }
+}
+
+/*!
+ *  Returns the current value of the manager.
+ */
+quint64 GroupedProgressManager::value() { return mCurrentValue; }
+
+/*!
+ *  Returns the maximum value of the manager.
+ *
+ *  This function will always return @c 100, and exists as a convenience method so that
+ *  user code does not need to remember this.
+ */
+quint64 GroupedProgressManager::maximum() { return UNIFIED_MAXIMUM; }
+
+//-Slots------------------------------------------------------------------------------------------------------------
+//Private:
+void GroupedProgressManager::childValueChanged() { updateValue(); }
+void GroupedProgressManager::childMaximumChanged() { updateValue(); }
+
+void GroupedProgressManager::childWeightChanged()
+{
+    updateRelativePortions();
+    updateValue();
+}
+
+//-Signals------------------------------------------------------------------------------------------------
+
+/*!
+ *  @fn void GroupedProgressManager::valueChanged(quint64 value)
+ *
+ *  This signal is emitted whenever the grouped progress manager's current @ref value changes.
+ *
+ *  @note Since this value is recalculated every time a progress group is added to the manager, in manner
+ *  that may result the value going up and down, it is recommended to not connect this signal to an
+ *  observer until the manager has been fully initialized for a given use.
+ */
+
+}

--- a/comp/core/src/qx-progressgroup.cpp
+++ b/comp/core/src/qx-progressgroup.cpp
@@ -1,0 +1,283 @@
+// Unit Includes
+#include "qx/core/qx-progressgroup.h"
+
+namespace Qx
+{
+
+//===============================================================================================================
+// ProgressGroup
+//===============================================================================================================
+
+/*!
+ *  @class ProgressGroup
+ *  @ingroup qx-core
+ *
+ *  @brief The ProgressGroup class represents a distinct portion of overall progress to be mediated by
+ *  GroupedProgressManager.
+ *
+ *  A ProgressGroup acts as a container that stores the progress of a single, or similarly natured step(s) of an
+ *  arbitrary task, along with a weight that dictates the group's significance when compared to other progress
+ *  groups.
+ *
+ *  @sa GroupedProgressManager, QProgressBar
+ */
+
+//-Class Properties-----------------------------------------------------------------------------------------------
+//Private:
+/*!
+ *  @property ProgressGroup::name
+ *  @brief The name of the progress group.
+ *
+ *  A progress group's name can only be set when it is constructed.
+ */
+
+/*!
+*  @property ProgressGroup::value
+*  @brief The current value of the progress group.
+*
+*  Attempting to change the current value to one outside the minimum-maximum range has no effect on the current value.
+*
+*  The minimum for a progress group's value is always @c 0.
+*
+*  The default value is @c 0.
+*/
+
+/*!
+*  @property ProgressGroup::maximum
+*  @brief The maximum value of the progress group.
+*
+*  When setting the maximum, if the current @ref value falls outside the new range, the progress bar is reset with reset().
+*
+*  The default value is @c 100.
+*/
+
+/*!
+*  @property ProgressGroup::weight
+*  @brief The weight of the progress group.
+*
+*  The weight of a progress group can never be reduced below @c 1.
+*
+*  The default value is @c 1.
+*/
+
+/*!
+*  @property ProgressGroup::proportionComplete
+*  @brief The progress group's proportion of completed progress.
+*
+*  This is expressed as a floating-point value between @c 0 and @c 1.
+*
+*  A progress group with a @ref maximum of @c 0 is considered to have a proportion complete of @c 0.
+*/
+
+//-Constructor----------------------------------------------------------------------------------------------
+//Public:
+
+/*!
+ *  Constructs a ProgressGroup with the specified @a name and @a parent.
+ *
+ *  @note Generally a progress group should only be made the child of a GroupedProgressManager via
+ *  GroupedProgressManager::addGroup().
+ */
+ProgressGroup::ProgressGroup(QString name, QObject* parent) :
+    QObject(parent),
+    mName(name),
+    mValue(0),
+    mMaximum(100),
+    mWeight(1),
+    mProportion(0)
+{
+    // Setup proportion binding
+    mProportion.setBinding([&](){ return mMaximum.value() ? static_cast<double>(mValue.value())/mMaximum.value() : 0; });
+    mProportionNotifier = mProportion.addNotifier([&]() { emit proportionCompleteChanged(mProportion); });
+}
+
+//-Instance Functions---------------------------------------------------------------------------------------------
+//Public:
+/*!
+ *  Returns the name of the progress group.
+ */
+QString ProgressGroup::name() const { return mName; }
+
+/*!
+ *  Returns the current value of the progress group.
+ */
+quint64 ProgressGroup::value() const { return mValue; }
+
+/*!
+ *  Returns the maximum value of the progress group.
+ */
+quint64 ProgressGroup::maximum() const { return mMaximum; }
+
+/*!
+ *  Returns the progress group's weight.
+ */
+quint64 ProgressGroup::weight() const { return mWeight; }
+
+/*!
+ *  Returns the progress group's proportion of completed progress.
+ */
+double ProgressGroup::proportionComplete() const { return mProportion; }
+
+/*!
+ *  Increments the current value of the progress group.
+ */
+void ProgressGroup::incrementValue()
+{
+    if(mValue == mMaximum)
+        return;
+
+    setValue(mValue + 1);
+}
+
+/*!
+ *  Decrements the current value of the progress group.
+ */
+void ProgressGroup::decrementValue()
+{
+    if(mValue == 0)
+        return;
+
+    setValue(mValue - 1);
+}
+
+/*!
+ *  Increments the maximum value of the progress group.
+ */
+void ProgressGroup::incrementMaximum() { setMaximum(mMaximum + 1); }
+
+/*!
+ *  Decrements the maximum value of the progress group.
+ */
+void ProgressGroup::decrementMaximum()
+{
+    if(mMaximum == 0)
+        return;
+
+    setMaximum(mMaximum - 1);
+}
+
+/*!
+ *  Adds @a amount to the progress group's current value.
+ */
+void ProgressGroup::increaseValue(quint64 amount)
+{
+    quint64 newValue = mValue + amount;
+    if(newValue > mMaximum)
+        return;
+
+    setValue(newValue);
+}
+
+/*!
+ *  Subtracts @a amount from the progress group's current value.
+ */
+void ProgressGroup::decreaseValue(quint64 amount)
+{
+    if(amount > mValue)
+        return;
+
+    setValue(mValue - amount);
+}
+
+/*!
+ *  Adds @a amount to the progress group's maximum value.
+ */
+void ProgressGroup::increaseMaximum(quint64 amount) { setMaximum(mMaximum + amount); }
+
+/*!
+ *  Subtracts @a amount from the progress group's maximum value.
+ */
+void ProgressGroup::decreaseMaximum(quint64 amount)
+{
+    if(amount > mMaximum)
+        setMaximum(0);
+    else
+        setMaximum(mMaximum - amount);
+}
+
+//-Slots------------------------------------------------------------------------------------------------------------
+//Public:
+/*!
+ *  Sets the current value of the progress group to @c 0.
+ */
+void ProgressGroup::reset() { setValue(0); }
+
+/*!
+ *  Sets the current value of the progress group to @a value.
+ */
+void ProgressGroup::setValue(quint64 value)
+{
+    if(value == mValue || value > mMaximum)
+        return;
+
+    mValue = value;
+
+    emit valueChanged(mValue);
+}
+
+/*!
+ *  Sets the maximum value of the progress group to @a value.
+ */
+void ProgressGroup::setMaximum(quint64 maximum)
+{
+    if(maximum == mMaximum)
+        return;
+
+    /* The value is changed within a property update group to prevent dependent
+     * properties from updating immediately since if reset() is called then
+     * mValue will be updated as well, and normally mProportion would be recalculated
+     * twice in that case; this prevents that. In this particular situation the overhead
+     * of the update group might be worse than just updating the value twice, but overall
+     * this is here, in part, to act as an example of Qt Bindable Properties.
+     */
+    Qt::beginPropertyUpdateGroup();
+    mMaximum = maximum;
+    if(mValue > mMaximum)
+        reset();
+    Qt::endPropertyUpdateGroup();
+
+    emit maximumChanged(mValue);
+}
+
+/*!
+ *  Sets the weight of the progress group to @a weight.
+ */
+void ProgressGroup::setWeight(quint64 weight)
+{
+    if(weight < 1)
+        weight = 1;
+
+    if(weight == mWeight)
+        return;
+
+    mWeight = weight;
+    emit weightChanged(mValue);
+}
+
+
+//-Signals------------------------------------------------------------------------------------------------
+
+/*!
+ *  @fn void ProgressGroup::valueChanged(quint64 value)
+ *
+ *  This signal is emitted whenever the progress group's current @ref value changes.
+ */
+
+/*!
+ *  @fn void ProgressGroup::maximumChanged(quint64 maximum)
+ *
+ *  This signal is emitted whenever the progress group's @ref maximum value changes.
+ */
+
+/*!
+ *  @fn void ProgressGroup::weightChanged(quint64 weight)
+ *
+ *  This signal is emitted whenever the progress group's @ref weight changes.
+ */
+
+/*!
+ *  @fn void ProgressGroup::proportionCompleteChanged(double proportion)
+ *
+ *  This signal is emitted whenever the progress group's @ref proportionComplete changes.
+ */
+}


### PR DESCRIPTION
Similar to Cumulation, but with a fixed type and more specialized for progress tracking.

Allows setting a weight to a group/category of progress and then adding that group to a tracker. The tracker then calculates an overall progress value based on the weights and completion of each individual group, which is automatically recalculated when any child group changes.

This allows for allocating a given group to specific portions of overall progress (i.e. that "File Copies" are 30% of overall progress), regardless of how many steps that group has individually.