### PR TITLE
Add missing doc enabler flag for Windows auto-builds

### DIFF
--- a/.github/workflows/build-qx-windows.yml
+++ b/.github/workflows/build-qx-windows.yml
@@ -97,7 +97,7 @@ jobs:
         echo "Setup C++ Build Environment..."
         CALL "${{ env.vs_dir }}\Common7\Tools\VsDevCmd.bat" -arch=amd64
         echo "Configure CMake using Qt wrapper..."
-        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.qx_src_dir}}" -B "${{ env.qx_build_dir }}"  
+        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.qx_src_dir}}" -B "${{ env.qx_build_dir }}" -D QX_DOCS_TARGET=ON
         echo "Changing to build directory..."
         cd "%qx_build_dir%"
         echo "Building Qx debug..."


### PR DESCRIPTION
When doc target enabler flag was added, errantly it was never included in the Windows auto build script.