### PR TITLE
Add Qx::abs, same as std::abs but with overloads for unsigned integers

### DIFF
--- a/comp/core/CMakeLists.txt
+++ b/comp/core/CMakeLists.txt
@@ -33,6 +33,7 @@ set(COMPONENT_PRIVATE_HEADERS
 
 # Source Files
 set(COMPONENT_IMPL
+    qx-algorithm.cpp
     qx-bitarray.cpp
     qx-char.cpp
     qx-datetime.cpp
@@ -52,7 +53,6 @@ set(COMPONENT_DOC_ONLY
     qx-regularexpression.dox
     qx-bytearray.dox
     qx-index.dox
-    qx-algorithm.dox
     qx-iostream.dox
     qx-list.dox
     qx-traverser.dox

--- a/comp/core/include/qx/core/qx-algorithm.h
+++ b/comp/core/include/qx/core/qx-algorithm.h
@@ -10,6 +10,13 @@
 namespace Qx
 {
 //-Namespace Functions----------------------------------------------------------------------------------------------------
+int abs(int n);
+unsigned int abs(unsigned int n);
+long abs(long n);
+unsigned long abs(unsigned long n);
+long long abs (long long n);
+unsigned long long abs(unsigned long long n);
+
 template<typename T>
     requires std::integral<T>
 T lengthOfRange(T start, T end) { return (end - start) + 1; }

--- a/comp/core/src/qx-algorithm.cpp
+++ b/comp/core/src/qx-algorithm.cpp
@@ -1,8 +1,51 @@
+// Unit Includes
+#include "qx/core/qx-algorithm.h"
+
+// Standard Library Includes
+#include <cmath>
+
 namespace Qx
 {
 /*! @addtogroup qx-core
  *  @{
  */
+
+//-Namespace Functions----------------------------------------------------------------------------------------------------
+/*!
+ *  Returns the absolute value of @a n; equivalent to @c std::abs(n) .
+ */
+int abs(int n) { return std::abs(n); }
+
+/*!
+ *  @overload
+ *
+ *  Returns the absolute value of @a n; equivalent to @c n.
+ *
+ *  This overload allows @c abs to be used in templates without the need to specialize solely because of signedness
+ */
+unsigned int abs(unsigned int n) { return n; }
+
+/*!
+ *  @overload
+ *  @copydoc abs(int n)
+ */
+long abs(long n) { return std::abs(n); }
+
+/*!
+ *  @copydoc abs(unsigned int n)
+ */
+unsigned long abs(unsigned long n) { return n; }
+
+/*!
+ *  @overload
+ *  @copydoc abs(int n)
+ */
+long long abs (long long n) { return std::abs(n); }
+
+/*!
+ *  @copydoc abs(unsigned int n)
+ */
+unsigned long long abs(unsigned long long n) { return n; }
 
 /*!
  *  @fn template<typename T> requires std::integral<T> T lengthOfRange(T start, T end)


### PR DESCRIPTION
This allows for its use in templates without having to discriminate
agaisnt signedness for a given implementation that otherwise would not
differ.