### PR TITLE
Fix Qx::roundToNearestMultiple not working for unsigned types

### DIFF
--- a/comp/core/include/qx/core/qx-algorithm.h
+++ b/comp/core/include/qx/core/qx-algorithm.h
@@ -139,10 +139,10 @@ static T constrainedDiv(T a, T b, T max = std::numeric_limits<T>::max())
 
 template<typename T>
 	requires std::integral<T>
-static T roundToNearestMultiple(T num, T mult)
+static T roundToNearestMultiple(T num, std::make_unsigned<T> mult)
 {
 	// Ignore negative multiples
-	mult = std::abs(mult);
+    //mult = std::abs(mult);
 
 	if(mult == 0)
 		return 0;

--- a/comp/core/include/qx/core/qx-algorithm.h
+++ b/comp/core/include/qx/core/qx-algorithm.h
@@ -149,11 +149,11 @@ static T constrainedDiv(T a, T b, T max = std::numeric_limits<T>::max())
 }
 
 template<typename T>
-	requires std::integral<T>
-static T roundToNearestMultiple(T num, std::make_unsigned<T> mult)
+    requires std::integral<T>
+static T roundToNearestMultiple(T num, T mult)
 {
-	// Ignore negative multiples
-    //mult = std::abs(mult);
+    // Ensure mult is positive
+    mult = Qx::abs(mult);
 
 	if(mult == 0)
 		return 0;
@@ -161,11 +161,11 @@ static T roundToNearestMultiple(T num, std::make_unsigned<T> mult)
 	if(mult == 1)
 		return num;
 
-	T towardsZero = (num / mult) * mult;
-	T awayFromZero = num < 0 ? constrainedSub(towardsZero, mult) : constrainedAdd(towardsZero, mult);
+    T towardsZero = (num / mult) * mult;
+    T awayFromZero = num < 0 ? constrainedSub(towardsZero, mult) : constrainedAdd(towardsZero, mult);
 
 	// Return of closest the two directions
-	return (abs(num) - abs(towardsZero) >= abs(awayFromZero) - abs(num))? awayFromZero : towardsZero;
+    return (distance(towardsZero, num) <= distance(awayFromZero, num)) ? towardsZero : awayFromZero;
 }
 
 template <typename T>

--- a/comp/core/src/qx-algorithm.cpp
+++ b/comp/core/src/qx-algorithm.cpp
@@ -139,7 +139,7 @@ unsigned long long abs(unsigned long long n) { return n; }
  *
  *  Returns the multiple of @a mult that @a num is closest to.
  *
- *  Negative values for @a mult are treated as their positive equivalent.
+ *  The sign of the result will always be the same sign as @a num, regardless of the sign of @a mult.
  */
 
 /*!


### PR DESCRIPTION
Implementation previous relied on std::abs, which has no overloads for unsigned integers.