### PR TITLE
Github Actions: Disambiguate between multiple Doxygen installs in Windows auto-builds

### DIFF
--- a/.github/workflows/build-qx-windows.yml
+++ b/.github/workflows/build-qx-windows.yml
@@ -93,11 +93,13 @@ jobs:
     - name: Build/Install Qx
       working-directory: ${{ env.qx_src_dir }}
       shell: cmd
+      env:
+        doxygen_root: C:\Program Files\doxygen # Required because of #42
       run: |
         echo "Setup C++ Build Environment..."
         CALL "${{ env.vs_dir }}\Common7\Tools\VsDevCmd.bat" -arch=amd64
         echo "Configure CMake using Qt wrapper..."
-        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.qx_src_dir}}" -B "${{ env.qx_build_dir }}" -D QX_DOCS_TARGET=ON
+        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.qx_src_dir}}" -B "${{ env.qx_build_dir }}" -D QX_DOCS_TARGET=ON -D Doxygen_ROOT="${{ env.doxygen_root }}"
         echo "Changing to build directory..."
         cd "%qx_build_dir%"
         echo "Building Qx debug..."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endforeach()
 
 if(QX_DOCS_TARGET)
     # Find Doxygen package
-    find_package(Doxygen
+    find_package(Doxygen 1.9.4
                  COMPONENTS dot
                  OPTIONAL_COMPONENTS mscgen dia
     )


### PR DESCRIPTION
Newer GitHub Windows Server 2022 runner images use a version of MinGW that includes a build of Doxygen 1.9.1. Due to limitations with CMake's FindDoxygen module, this version effectively shadows the seperately installed and desired version of 1.9.4. 

This workaround sets `Doxygen_ROOT` to the path of the desired version to insure that it is found and selected by the FindDoxygen module.

This issue was reported here: https://gitlab.kitware.com/cmake/cmake/-/issues/23692

Fixes #42 