### PR TITLE
Merge to master for release v0.3.0.3

### DIFF
--- a/.github/workflows/build-qx-windows.yml
+++ b/.github/workflows/build-qx-windows.yml
@@ -93,11 +93,13 @@ jobs:
     - name: Build/Install Qx
       working-directory: ${{ env.qx_src_dir }}
       shell: cmd
+      env:
+        doxygen_root: C:\Program Files\doxygen # Required because of #42
       run: |
         echo "Setup C++ Build Environment..."
         CALL "${{ env.vs_dir }}\Common7\Tools\VsDevCmd.bat" -arch=amd64
         echo "Configure CMake using Qt wrapper..."
-        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.qx_src_dir}}" -B "${{ env.qx_build_dir }}" -D QX_DOCS_TARGET=ON
+        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.qx_src_dir}}" -B "${{ env.qx_build_dir }}" -D QX_DOCS_TARGET=ON -D Doxygen_ROOT="${{ env.doxygen_root }}"
         echo "Changing to build directory..."
         cd "%qx_build_dir%"
         echo "Building Qx debug..."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(QX_DOCS_TARGET "Build Qx documentation" OFF)
 # NOTE: For versions stick to w.x.y.z, where z is generally
 # avoided and only used for hotfixes. DON'T USE TRAILING
 # ZEROS IN VERSIONS
-set(QX_BASE_VERSION 0.3.0.2) # Required for CI/CD
+set(QX_BASE_VERSION 0.3.0.3) # Required for CI/CD
 project(Qx
     VERSION ${QX_BASE_VERSION}
     LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endforeach()
 
 if(QX_DOCS_TARGET)
     # Find Doxygen package
-    find_package(Doxygen
+    find_package(Doxygen 1.9.4
                  COMPONENTS dot
                  OPTIONAL_COMPONENTS mscgen dia
     )


### PR DESCRIPTION
Fixes missing Windows documentation (again) caused by recent GitHub Windows Server 2022 runner image update (and CMake).