### PR TITLE
Expand TextStreamWriter API coverage of QTextStream

### DIFF
--- a/comp/io/include/qx/io/qx-textstreamwriter.h
+++ b/comp/io/include/qx/io/qx-textstreamwriter.h
@@ -28,6 +28,31 @@ public:
 
 //-Instance Functions------------------------------------------------------------------------------------------------
 public:
+    // Stock functions
+    QStringConverter::Encoding encoding() const;
+    void flush();
+    bool generateByteOrderMark() const;
+    int integerBase() const;
+    QLocale locale() const;
+    QTextStream::NumberFlags numberFlags() const;
+    QTextStream::RealNumberNotation realNumberNotation() const;
+    int realNumberPrecision() const;
+    void reset();
+    void resetStatus();
+    void setEncoding(QStringConverter::Encoding encoding);
+    void setGenerateByteOrderMark(bool generate);
+    void setIntegerBase(int base);
+    void setLocale(const QLocale& locale);
+    void setNumberFlags(QTextStream::NumberFlags flags);
+    void setRealNumberNotation(QTextStream::RealNumberNotation notation);
+    void setRealNumberPrecision(int precision);
+    IoOpReport status() const;
+
+    template<typename T>
+        requires defines_left_shift_for<QTextStream, T>
+    TextStreamWriter& operator<<(T d) { mStreamWriter << d; return *this; }
+
+    // New functions
     IoOpReport openFile();
     IoOpReport writeLine(QString line, bool ensureLineStart = true);
     IoOpReport writeText(QString text);

--- a/comp/io/src/qx-filestreamwriter.cpp
+++ b/comp/io/src/qx-filestreamwriter.cpp
@@ -66,7 +66,7 @@ QDataStream::FloatingPointPrecision FileStreamWriter::floatingPointPrecision() c
 /*!
  *  Resets the status of the file stream writer.
  *
- *  @sa QDataStream::Status, and status().
+ *  @sa status().
  */
 void FileStreamWriter::resetStatus() { mStreamWriter.resetStatus(); }
 

--- a/comp/io/src/qx-textstreamwriter.cpp
+++ b/comp/io/src/qx-textstreamwriter.cpp
@@ -51,6 +51,161 @@ TextStreamWriter::TextStreamWriter(QFile* file, WriteMode writeMode, WriteOption
 //-Instance Functions--------------------------------------------------------------------------------------------
 //Public:
 /*!
+ *  Returns the encoding that is current assigned to the stream.
+ *
+ *  @sa setEncoding(), and local().
+ */
+QStringConverter::Encoding TextStreamWriter::encoding() const { return mStreamWriter.encoding(); }
+
+/*!
+ *  Flushes any buffered data waiting to be written to the device.
+ *
+ *  If the stream was constructed with WriteOption::Unbuffered, this function does nothing.
+ */
+void TextStreamWriter::flush() { mStreamWriter.flush(); }
+
+/*!
+ *  Returns @c true if QTextStream is set to generate the UTF BOM (Byte Order Mark) when using a UTF encoding;
+ *  otherwise returns @c false.
+ *
+ *  UTF BOM generation is set to false by default.
+ *
+ *  @sa setGenerateByteOrderMark().
+ */
+bool TextStreamWriter::generateByteOrderMark() const { return mStreamWriter.generateByteOrderMark(); }
+
+/*!
+ * Returns the current base of integers. @c 0 means that the base is @c 10 (decimal) when generating numbers.
+ *
+ * @sa setIntegerBase(), QString::number(), and numberFlags().
+ */
+int TextStreamWriter::integerBase() const { return mStreamWriter.integerBase(); }
+
+/*!
+ *  Returns the locale for this stream. The default locale is @c C.
+ *
+ *  @sa setLocale().
+ */
+QLocale TextStreamWriter::locale() const { return mStreamWriter.locale(); }
+
+/*!
+ *  Returns the current number flags.
+ *
+ *  @sa setNumberFlags(), integerBase(), and realNumberNotation().
+ */
+QTextStream::NumberFlags TextStreamWriter::numberFlags() const { return mStreamWriter.numberFlags(); }
+
+/*!
+ *  Returns the current real number notation.
+ *
+ *  @sa setRealNumberNotation(), realNumberPrecision(), numberFlags(), and integerBase().
+ */
+QTextStream::RealNumberNotation TextStreamWriter::realNumberNotation() const { return mStreamWriter.realNumberNotation(); }
+
+/*!
+ *  Returns the current real number precision, or the number of fraction digits TextStreamWriter will write when
+ *  generating real numbers.
+ *
+ *  @sa setRealNumberPrecision(), setRealNumberNotation(), realNumberNotation(), numberFlags(), and integerBase().
+ */
+int TextStreamWriter::realNumberPrecision() const { return mStreamWriter.realNumberPrecision(); }
+
+/*!
+ *  Resets TextStreamWriter's formatting options, bringing it back to its original constructed state. The device,
+ *  string and any buffered data is left untouched.
+ */
+void TextStreamWriter::reset() { return mStreamWriter.reset(); }
+
+/*!
+ *  Resets the status of the text stream.
+ *
+ *  @sa status().
+ */
+void TextStreamWriter::resetStatus() { return mStreamWriter.resetStatus(); }
+
+/*!
+ *  Sets the encoding for this stream to @a encoding. The encoding is used for any data that is written. By default,
+ *  QStringConverter::Utf8 is used.
+ *
+ *  @sa encoding(), and setLocale().
+ */
+void TextStreamWriter::setEncoding(QStringConverter::Encoding encoding) { mStreamWriter.setEncoding(encoding); }
+
+/*!
+ *  If @a generate is @c true and a UTF encoding is used, QTextStream will insert the BOM (Byte Order Mark) before
+ *  any data has been written to the device. If @a generate is @c false, no BOM will be inserted. This function must
+ *  be called before any data is written. Otherwise, it does nothing.
+ *
+ *  @sa generateByteOrderMark().
+ */
+void TextStreamWriter::setGenerateByteOrderMark(bool generate) { mStreamWriter.setGenerateByteOrderMark(generate); }
+
+/*!
+ *  Sets the base of integers to @a base. @a base can be either @c 2 (binary), @c 8 (octal), @c 10 (decimal) or @c 16
+ *  (hexadecimal). QTextStream assumes base is @c 10 unless the base has been set explicitly.
+ *
+ *  @sa integerBase(), QString::number(), and setNumberFlags().
+ */
+void TextStreamWriter::setIntegerBase(int base) { mStreamWriter.setIntegerBase(base); }
+
+/*!
+ *  Sets the locale for this stream to @a locale. The specified locale is used for conversions between numbers and
+ *  their string representations.
+ *
+ *  The default locale is @c C and it is a special case - the thousands group separator is not used for backward
+ *  compatibility reasons.
+ *
+ *  @sa locale().
+ */
+void TextStreamWriter::setLocale(const QLocale& locale) { mStreamWriter.setLocale(locale); }
+
+/*!
+ *  Sets the current number flags to @a flags. @a flags is a set of flags from the QTextStream::NumberFlag enum,
+ *  and describes options for formatting generated code (e.g., whether or not to always write the base or sign of
+ *  a number).
+ *
+ *  @sa numberFlags(), setIntegerBase(), and setRealNumberNotation().
+ */
+void TextStreamWriter::setNumberFlags(QTextStream::NumberFlags flags) { mStreamWriter.setNumberFlags(flags); }
+
+/*!
+ *  Sets the real number notation to @a notation. When generating numbers, TextStreamWriter uses this value to detect
+ *  the formatting of real numbers.
+ *
+ *  @sa realNumberNotation(), setRealNumberPrecision(), setNumberFlags(), and setIntegerBase().
+ */
+void TextStreamWriter::setRealNumberNotation(QTextStream::RealNumberNotation notation) { mStreamWriter.setRealNumberNotation(notation); }
+
+/*!
+ *  Sets the precision of real numbers to @a precision. This value describes the number of fraction digits
+ *  TextStreamWriter should write when generating real numbers.
+ *
+ *  The precision cannot be a negative value. The default value is @c 6.
+ *
+ *  @sa realNumberPrecision() and setRealNumberNotation().
+ */
+void TextStreamWriter::setRealNumberPrecision(int precision) { mStreamWriter.setRealNumberPrecision(precision); }
+
+/*!
+ *  Returns the status of the text stream writer.
+ *
+ *  @sa resetStatus().
+ */
+IoOpReport TextStreamWriter::status() const
+{
+    return IoOpReport(IoOpType::IO_OP_WRITE, TXT_STRM_STAT_MAP.value(mStreamWriter.status()), *mTargetFile);
+}
+
+/*!
+ *  @fn template<typename T> requires defines_left_shift_for<QTextStream, T> TextStreamWriter& TextStreamWriter::operator<<(T d)
+ *
+ *  Writes @a d of type @c T to the stream. Returns a reference to the stream.
+ *
+ *  This template is constrained such that effectively, the insertion operator for this class is available
+ *  for all data types that QTextStream defines an insertion operator for.
+ */
+
+/*!
  *  Opens the text file associated with the text stream writer and returns an operation report.
  *
  *  This function must be called before any data is written, unless the file already open
@@ -97,7 +252,7 @@ IoOpReport TextStreamWriter::openFile()
 }
 
 /*!
- *  Writes @a line to the stream, followed by a line break.
+ *  Writes @a line to the stream followed by a line break and returns the streams @ref status.
  *
  *  If @a ensureLineStart is true, a line break will be written before writing @a line if the stream wasn't
  *  already positioned at the start of a new line.
@@ -119,14 +274,14 @@ IoOpReport TextStreamWriter::writeLine(QString line, bool ensureLineStart)
         mAtLineStart = true;
 
         // Return stream status
-        return IoOpReport(IO_OP_WRITE, TXT_STRM_STAT_MAP.value(mStreamWriter.status()), *mTargetFile);
+        return status();
     }
     else
         return IoOpReport(IO_OP_WRITE, IO_ERR_FILE_NOT_OPEN, *mTargetFile);
 }
 
 /*!
- *  Writes @a text to the stream. No line break is written afterwards.
+ *  Writes @a text to the stream and returns the stream's @ref status.
  */
 IoOpReport TextStreamWriter::writeText(QString text)
 {


### PR DESCRIPTION
Covers the "writing scoped" original functionality of QTextStream more completely, similar to how FileStreamWriter handled portions of the QDataStream API