### PR TITLE
Add convenience function 'hasError()' to all stream readers/writers

### DIFF
--- a/comp/io/include/qx/io/qx-filestreamreader.h
+++ b/comp/io/include/qx/io/qx-filestreamreader.h
@@ -45,6 +45,7 @@ public:
     QFile* file();
 
     // New functions
+    bool hasError();
     IoOpReport openFile();
     void closeFile();
 };	

--- a/comp/io/include/qx/io/qx-filestreamwriter.h
+++ b/comp/io/include/qx/io/qx-filestreamwriter.h
@@ -42,6 +42,7 @@ public:
     QFile* file();
 
     // New functions
+    bool hasError();
     IoOpReport openFile();
     void closeFile();
 };

--- a/comp/io/include/qx/io/qx-textstreamreader.h
+++ b/comp/io/include/qx/io/qx-textstreamreader.h
@@ -52,6 +52,7 @@ public:
     TextStreamReader& operator>>(T& d) { mStreamReader >> d; return *this; }
 
     // New functions
+    bool hasError();
     IoOpReport openFile();
     void closeFile();
 };

--- a/comp/io/include/qx/io/qx-textstreamwriter.h
+++ b/comp/io/include/qx/io/qx-textstreamwriter.h
@@ -53,9 +53,10 @@ public:
     TextStreamWriter& operator<<(T d) { mStreamWriter << d; return *this; }
 
     // New functions
-    IoOpReport openFile();
+    bool hasError();
     IoOpReport writeLine(QString line, bool ensureLineStart = true);
     IoOpReport writeText(QString text);
+    IoOpReport openFile();
     void closeFile();
 };	
 

--- a/comp/io/src/qx-filestreamreader.cpp
+++ b/comp/io/src/qx-filestreamreader.cpp
@@ -167,6 +167,13 @@ IoOpReport FileStreamReader::status()
 QFile* FileStreamReader::file() { return mSourceFile; }
 
 /*!
+ *  Returns @c true if the stream's current status indicates that an error has occurred; otherwise, returns @c false.
+ *
+ *  Equivalent to `!status().wasSuccessful()`.
+ */
+bool FileStreamReader::hasError() { return status().wasSuccessful(); }
+
+/*!
  *  Opens the file associated with the file stream reader and returns an operation report.
  *
  *  This function must be called before any data is read, unless the file is already open

--- a/comp/io/src/qx-filestreamwriter.cpp
+++ b/comp/io/src/qx-filestreamwriter.cpp
@@ -146,6 +146,13 @@ IoOpReport FileStreamWriter::writeRawData(const QByteArray& data)
 QFile* FileStreamWriter::file() { return mTargetFile; }
 
 /*!
+ *  Returns @c true if the stream's current status indicates that an error has occurred; otherwise, returns @c false.
+ *
+ *  Equivalent to `!status().wasSuccessful()`.
+ */
+bool FileStreamWriter::hasError() { return status().wasSuccessful(); }
+
+/*!
  *  Opens the file associated with the file stream writer and returns an operation report.
  *
  *  This function must be called before any data is written, unless the file is already open

--- a/comp/io/src/qx-textstreamreader.cpp
+++ b/comp/io/src/qx-textstreamreader.cpp
@@ -249,6 +249,13 @@ IoOpReport TextStreamReader::status() const
  */
 
 /*!
+ *  Returns @c true if the stream's current status indicates that an error has occurred; otherwise, returns @c false.
+ *
+ *  Equivalent to `!status().wasSuccessful()`.
+ */
+bool TextStreamReader::hasError() { return status().wasSuccessful(); }
+
+/*!
  *  Opens the text file associated with the text stream reader and returns an operation report.
  *
  *  This function must be called before any data is read, unless the file is already open


### PR DESCRIPTION
Shortcut for !stream.status().wasSuccessful()