### PR TITLE
Improve ability to handle null files in IO handling

### DIFF
--- a/comp/io/include/qx/io/qx-ioopreport.h
+++ b/comp/io/include/qx/io/qx-ioopreport.h
@@ -15,11 +15,11 @@ namespace Qx
 	
 //-Types------------------------------------------------------------------------------------------------------
 enum IoOpType { IO_OP_READ, IO_OP_WRITE, IO_OP_ENUMERATE, IO_OP_INSPECT };
-enum IoOpResultType { IO_SUCCESS, IO_ERR_UNKNOWN, IO_ERR_ACCESS_DENIED, IO_ERR_NOT_A_FILE, IO_ERR_NOT_A_DIR, IO_ERR_OUT_OF_RES,
+enum IoOpResultType { IO_SUCCESS, IO_ERR_UNKNOWN, IO_ERR_ACCESS_DENIED, IO_ERR_WRONG_TYPE, IO_ERR_OUT_OF_RES,
                       IO_ERR_READ, IO_ERR_WRITE, IO_ERR_FATAL, IO_ERR_OPEN, IO_ERR_ABORT,
                       IO_ERR_TIMEOUT, IO_ERR_REMOVE, IO_ERR_RENAME, IO_ERR_REPOSITION,
-                      IO_ERR_RESIZE, IO_ERR_COPY, IO_ERR_FILE_DNE, IO_ERR_DIR_DNE,
-                      IO_ERR_FILE_EXISTS, IO_ERR_CANT_MAKE_DIR, IO_ERR_FILE_SIZE_MISMATCH, IO_ERR_CURSOR_OOB,
+                      IO_ERR_RESIZE, IO_ERR_COPY, IO_ERR_DNE, IO_ERR_NULL,
+                      IO_ERR_EXISTS, IO_ERR_CANT_CREATE, IO_ERR_FILE_SIZE_MISMATCH, IO_ERR_CURSOR_OOB,
                       IO_ERR_FILE_NOT_OPEN};
 enum IoOpTargetType { IO_FILE, IO_DIR };
 
@@ -30,7 +30,11 @@ class IoOpReport
 //-Class Members----------------------------------------------------------------------------------------------------
 private:
     static const inline QString NULL_TARGET = "<NULL>";
-    static const inline QStringList TARGET_TYPES  = {"file", "directory"};
+    static const inline QString TYPE_MACRO = "<target>";
+    static const inline QHash<IoOpTargetType, QString> TARGET_TYPE_STRINGS  = {
+        {IO_FILE, "file"},
+        {IO_DIR, "directory"}
+    };
     static const inline QString SUCCESS_TEMPLATE = R"(Successfully %1 %2 "%3")";
     static const inline QString ERROR_TEMPLATE = R"(Error while %1 %2 "%3")";
     static const inline QHash<IoOpType, QString> SUCCESS_VERBS = {
@@ -48,28 +52,31 @@ private:
     static const inline QHash<IoOpResultType, QString> ERROR_INFO = {
         {IO_ERR_UNKNOWN, "An unknown error has occurred."},
         {IO_ERR_ACCESS_DENIED, "Access denied."},
-        {IO_ERR_NOT_A_FILE, "Target is not a file."},
-        {IO_ERR_NOT_A_DIR, "Target is not a directory."},
+        {IO_ERR_WRONG_TYPE, "Target is not a " + TYPE_MACRO + "."},
         {IO_ERR_OUT_OF_RES, "Out of resources."},
         {IO_ERR_READ, "General read error."},
         {IO_ERR_WRITE, "General write error."},
         {IO_ERR_FATAL, "A fatal error has occurred."},
-        {IO_ERR_OPEN, "Could not open file."},
+        {IO_ERR_OPEN, "Could not open " + TYPE_MACRO + "."},
         {IO_ERR_ABORT, "The operation was aborted."},
         {IO_ERR_TIMEOUT, "Request timed out."},
-        {IO_ERR_REMOVE, "The file could not be removed."},
-        {IO_ERR_RENAME, "The file could not be renamed."},
-        {IO_ERR_REPOSITION, "The file could not be moved."},
-        {IO_ERR_RESIZE, "The file could not be resized."},
-        {IO_ERR_COPY, "The file could not be copied."},
-        {IO_ERR_FILE_DNE, "File does not exist."},
-        {IO_ERR_DIR_DNE, "Directory does not exist."},
-        {IO_ERR_FILE_EXISTS, "The file already exists."},
-        {IO_ERR_CANT_MAKE_DIR, "The directory could not be created."},
+        {IO_ERR_REMOVE, "The " + TYPE_MACRO + " could not be removed."},
+        {IO_ERR_RENAME, "The " + TYPE_MACRO + " could not be renamed."},
+        {IO_ERR_REPOSITION, "The " + TYPE_MACRO + " could not be moved."},
+        {IO_ERR_RESIZE, "The " + TYPE_MACRO + " could not be resized."},
+        {IO_ERR_COPY, "The " + TYPE_MACRO + " could not be copied."},
+        {IO_ERR_DNE, "The " + TYPE_MACRO + " does not exist."},
+        {IO_ERR_NULL, "The target is null"},
+        {IO_ERR_EXISTS, "The " + TYPE_MACRO + " already exists."},
+        {IO_ERR_CANT_CREATE, "The " + TYPE_MACRO + " could not be created."},
         {IO_ERR_FILE_SIZE_MISMATCH, "File size mismatch."},
         {IO_ERR_CURSOR_OOB, "File data cursor has gone out of bounds."},
         {IO_ERR_FILE_NOT_OPEN, "The file is not open."}
     };
+    /* TODO: In the many const QHashs like this throughout the lib, figure out how to also
+     * make the values const (for since they aren't to be modified), because as is they don't
+     * compile that way.
+     */
 
 //-Instance Members-------------------------------------------------------------------------------------------------
 private:

--- a/comp/io/src/qx-common-io.cpp
+++ b/comp/io/src/qx-common-io.cpp
@@ -170,7 +170,7 @@ bool fileIsEmpty(const QFile& file) { return file.size() == 0; }
 IoOpReport fileIsEmpty(bool& returnBuffer, const QFile& file)
 {
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(file);
+    IoOpResultType fileCheckResult = fileCheck(&file, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
     {
         // File doesn't exist
@@ -227,7 +227,7 @@ IoOpReport textFileEndsWithNewline(bool& returnBuffer, QFile& textFile)
     returnBuffer = false;
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(textFile);
+    IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_INSPECT, fileCheckResult, textFile);
 
@@ -280,7 +280,7 @@ IoOpReport textFileLayout(QList<int>& returnBuffer, QFile& textFile, bool ignore
     returnBuffer.clear();
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(textFile);
+    IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_ENUMERATE, fileCheckResult, textFile);
 
@@ -325,7 +325,7 @@ IoOpReport textFileLineCount(int& returnBuffer, QFile& textFile, bool ignoreTrai
     returnBuffer = 0;
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(textFile);
+    IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_ENUMERATE, fileCheckResult, textFile);
 
@@ -428,7 +428,7 @@ IoOpReport findStringInFile(QList<TextPos>& returnBuffer, QFile& textFile, const
         return IoOpReport(IO_OP_INSPECT, IO_SUCCESS, textFile);
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(textFile);
+    IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_INSPECT, fileCheckResult, textFile);
 
@@ -567,7 +567,7 @@ IoOpReport readTextFromFile(QString& returnBuffer, QFile& textFile, TextPos star
     returnBuffer = QString();
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(textFile);
+    IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_READ, fileCheckResult, textFile);
 
@@ -682,7 +682,7 @@ IoOpReport readTextFromFile(QString& returnBuffer, QFile& textFile, TextPos star
     returnBuffer = QString();
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(textFile);
+    IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_READ, fileCheckResult, textFile);
 
@@ -813,7 +813,7 @@ IoOpReport readTextFromFile(QStringList& returnBuffer, QFile& textFile, Index32 
      returnBuffer = QStringList();
 
      // Check file
-     IoOpResultType fileCheckResult = fileCheck(textFile);
+     IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
      if(fileCheckResult != IO_SUCCESS)
          return IoOpReport(IO_OP_READ, fileCheckResult, textFile);
 
@@ -901,7 +901,7 @@ IoOpReport writeStringToFile(QFile& textFile, const QString& text, WriteMode wri
 
     // Perform write preparations
     bool existingFile;
-    IoOpReport prepResult = writePrep(existingFile, textFile, writeOptions);
+    IoOpReport prepResult = writePrep(existingFile, &textFile, writeOptions);
     if(!prepResult.wasSuccessful())
         return prepResult;
 
@@ -1081,7 +1081,7 @@ IoOpReport deleteTextFromFile(QFile& textFile, TextPos startPos, TextPos endPos)
         //TODO: create exception class that prints error and stashes the exception properly
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(textFile);
+    IoOpResultType fileCheckResult = fileCheck(&textFile, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_READ, fileCheckResult, textFile);
 
@@ -1275,7 +1275,7 @@ IoOpReport calculateFileChecksum(QString& returnBuffer, QFile& file, QCryptograp
     returnBuffer = QString();
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(file);
+    IoOpResultType fileCheckResult = fileCheck(&file, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_READ, fileCheckResult, file);
 
@@ -1347,7 +1347,7 @@ IoOpReport readBytesFromFile(QByteArray& returnBuffer, QFile& file, Index64 star
     returnBuffer.clear();
 
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(file);
+    IoOpResultType fileCheckResult = fileCheck(&file, Existance::Exist);
     if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_READ, fileCheckResult, file);
 
@@ -1418,7 +1418,7 @@ IoOpReport writeBytesToFile(QFile& file, const QByteArray& bytes, WriteMode writ
 
     // Perform write preparations
     bool existingFile;
-    IoOpReport prepResult = writePrep(existingFile, file, writeOptions);
+    IoOpReport prepResult = writePrep(existingFile, &file, writeOptions);
     if(!prepResult.wasSuccessful())
         return prepResult;
 

--- a/comp/io/src/qx-common-io_p.h
+++ b/comp/io/src/qx-common-io_p.h
@@ -13,17 +13,21 @@ namespace Qx
 {
 /*! @cond */
 
+//-Component Private Enums -------------------------------------------------------------------------------------------------
+enum class Existance {Exist, NotExist, Either};
+
 //-Component Private Variables ---------------------------------------------------------------------------------------------
 extern const QHash<QFileDevice::FileError, IoOpResultType> FILE_DEV_ERR_MAP;
 extern const QHash<QTextStream::Status, IoOpResultType> TXT_STRM_STAT_MAP;
 extern const QHash<QDataStream::Status, IoOpResultType> DATA_STRM_STAT_MAP;
 
 //-Component Private Functions-----------------------------------------------------------------------------------------------------
+Existance existanceReqFromWriteOptions(WriteOptions wo);
 IoOpResultType parsedOpen(QFile& file, QIODevice::OpenMode openMode);
-IoOpResultType fileCheck(const QFile& file);
+IoOpResultType fileCheck(const QFile* file, Existance existanceRequirement);
 IoOpResultType directoryCheck(QDir& dir);
 IoOpReport handlePathCreation(const QFile& file, bool createPaths);
-IoOpReport writePrep(bool& fileExists, QFile& file, WriteOptions writeOptions);
+IoOpReport writePrep(bool& fileExists, QFile* file, WriteOptions writeOptions);
 void matchAppendConditionParams(WriteMode& writeMode, TextPos& startPos);
 
 template<typename T>

--- a/comp/io/src/qx-filestreamreader.cpp
+++ b/comp/io/src/qx-filestreamreader.cpp
@@ -182,9 +182,9 @@ bool FileStreamReader::hasError() { return status().wasSuccessful(); }
 IoOpReport FileStreamReader::openFile()
 {
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(*mSourceFile);
+    IoOpResultType fileCheckResult = fileCheck(mSourceFile, Existance::Exist);
 
-    if(fileCheckResult == IO_ERR_NOT_A_FILE)
+    if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_WRITE, fileCheckResult, *mSourceFile);
 
     // Attempt to open file

--- a/comp/io/src/qx-filestreamwriter.cpp
+++ b/comp/io/src/qx-filestreamwriter.cpp
@@ -162,7 +162,7 @@ IoOpReport FileStreamWriter::openFile()
 {
     // Perform write preparations
     bool fileExists;
-    IoOpReport prepResult = writePrep(fileExists, *mTargetFile, mWriteOptions);
+    IoOpReport prepResult = writePrep(fileExists, mTargetFile, mWriteOptions);
     if(!prepResult.wasSuccessful())
         return prepResult;
 

--- a/comp/io/src/qx-textstreamreader.cpp
+++ b/comp/io/src/qx-textstreamreader.cpp
@@ -264,9 +264,9 @@ bool TextStreamReader::hasError() { return status().wasSuccessful(); }
 IoOpReport TextStreamReader::openFile()
 {
     // Check file
-    IoOpResultType fileCheckResult = fileCheck(*mSourceFile);
+    IoOpResultType fileCheckResult = fileCheck(mSourceFile, Existance::Either);
 
-    if(fileCheckResult == IO_ERR_NOT_A_FILE)
+    if(fileCheckResult != IO_SUCCESS)
         return IoOpReport(IO_OP_WRITE, fileCheckResult, *mSourceFile);
 
     // Attempt to open file

--- a/comp/io/src/qx-textstreamwriter.cpp
+++ b/comp/io/src/qx-textstreamwriter.cpp
@@ -273,7 +273,7 @@ IoOpReport TextStreamWriter::openFile()
 {
     // Perform write preparations
     bool existingFile;
-    IoOpReport prepResult = writePrep(existingFile, *mTargetFile, mWriteOptions);
+    IoOpReport prepResult = writePrep(existingFile, mTargetFile, mWriteOptions);
     if(!prepResult.wasSuccessful())
         return prepResult;
 


### PR DESCRIPTION
Improves ability to accept pointers (and handle null ones) for file operations in Qx::Io, namely in IoOpReport and fileCheck() in qx-common-io_p