### PR TITLE
Change IoOpReport::wasSuccessful() to ::isFailure() for clearer paradigm

### DIFF
--- a/comp/io/include/qx/io/qx-ioopreport.h
+++ b/comp/io/include/qx/io/qx-ioopreport.h
@@ -84,9 +84,9 @@ private:
     IoOpType mOperation;
     IoOpResultType mResult;
     IoOpTargetType mTargetType;
-    QString mTarget = QString();
-    QString mOutcome = QString();
-    QString mOutcomeInfo = QString();
+    QString mTarget;
+    QString mOutcome;
+    QString mOutcomeInfo;
 
 //-Constructor-------------------------------------------------------------------------------------------------------
 public:
@@ -107,7 +107,7 @@ public:
     QString target() const;
     QString outcome() const;
     QString outcomeInfo() const;
-    bool wasSuccessful() const;
+    bool isFailure() const;
     bool isNull() const;
     GenericError toGenericError() const;
 };

--- a/comp/io/src/qx-common-io.cpp
+++ b/comp/io/src/qx-common-io.cpp
@@ -377,7 +377,7 @@ IoOpReport textFileAbsolutePosition(TextPos& textPos, QFile& textFile, bool igno
     // Get file layout
     QList<int> textLayout;
     IoOpReport layoutCheck = textFileLayout(textLayout, textFile, ignoreTrailingEmpty);
-    if(!layoutCheck.wasSuccessful())
+    if(layoutCheck.isFailure())
         return layoutCheck;
 
     // Return null pos if text file is empty
@@ -447,7 +447,7 @@ IoOpReport findStringInFile(QList<TextPos>& returnBuffer, QFile& textFile, const
     if(trueStartPos != TextPos::START)
     {
         IoOpReport translate = textFileAbsolutePosition(trueStartPos, textFile, readOptions.testFlag(IgnoreTrailingBreak));
-        if(!translate.wasSuccessful())
+        if(translate.isFailure())
             return IoOpReport(IO_OP_INSPECT, translate.result(), textFile);
 
         // Return if position is outside bounds
@@ -902,7 +902,7 @@ IoOpReport writeStringToFile(QFile& textFile, const QString& text, WriteMode wri
     // Perform write preparations
     bool existingFile;
     IoOpReport prepResult = writePrep(existingFile, &textFile, writeOptions);
-    if(!prepResult.wasSuccessful())
+    if(prepResult.isFailure())
         return prepResult;
 
     // Ensure file is closed upon return
@@ -919,7 +919,7 @@ IoOpReport writeStringToFile(QFile& textFile, const QString& text, WriteMode wri
         {
             bool onNewLine;
             IoOpReport inspectResult = textFileEndsWithNewline(onNewLine, textFile);
-            if(!inspectResult.wasSuccessful())
+            if(inspectResult.isFailure())
                 return IoOpReport(IO_OP_WRITE, inspectResult.result(), textFile);
             needsNewLine = !onNewLine;
         }
@@ -970,7 +970,7 @@ IoOpReport writeStringToFile(QFile& textFile, const QString& text, WriteMode wri
         // Fill beforeNew
         TextPos beforeEnd = TextPos(startPos.line(), startPos.character() - 1);
         IoOpReport readBefore = readTextFromFile(beforeNew, textFile, TextPos::START, beforeEnd);
-        if(!readBefore.wasSuccessful())
+        if(readBefore.isFailure())
             return readBefore;
 
         // Pad beforeNew if required
@@ -1007,7 +1007,7 @@ IoOpReport writeStringToFile(QFile& textFile, const QString& text, WriteMode wri
         {
             // This will return a null string if there is no afterNew anyway, even without padding enabled
             IoOpReport readAfter = readTextFromFile(afterNew, textFile, startPos);
-            if(!readAfter.wasSuccessful())
+            if(readAfter.isFailure())
                 return readAfter;
         }
 
@@ -1315,7 +1315,7 @@ IoOpReport fileMatchesChecksum(bool& returnBuffer, QFile& file, QString checksum
     QString fileChecksum;
     IoOpReport checksumReport = calculateFileChecksum(fileChecksum, file, hashAlgorithm);
 
-    if(!checksumReport.wasSuccessful())
+    if(checksumReport.isFailure())
         return checksumReport;
 
     // Compare
@@ -1419,7 +1419,7 @@ IoOpReport writeBytesToFile(QFile& file, const QByteArray& bytes, WriteMode writ
     // Perform write preparations
     bool existingFile;
     IoOpReport prepResult = writePrep(existingFile, &file, writeOptions);
-    if(!prepResult.wasSuccessful())
+    if(prepResult.isFailure())
         return prepResult;
 
     // Post data for Inserts and Overwrites
@@ -1429,7 +1429,7 @@ IoOpReport writeBytesToFile(QFile& file, const QByteArray& bytes, WriteMode writ
     if(existingFile && writeMode == Insert)
     {
         Qx::IoOpReport readAfter = Qx::readBytesFromFile(afterNew, file, startPos);
-        if(!readAfter.wasSuccessful())
+        if(readAfter.isFailure())
             return readAfter;
     }
 

--- a/comp/io/src/qx-common-io_p.cpp
+++ b/comp/io/src/qx-common-io_p.cpp
@@ -118,7 +118,7 @@ IoOpReport writePrep(bool& fileExists, QFile* file, WriteOptions writeOptions)
 	{
 		// Make folders if wanted and necessary
         IoOpReport pathCreationResult = handlePathCreation(*file, writeOptions.testFlag(CreatePath));
-		if(!pathCreationResult.wasSuccessful())
+        if(pathCreationResult.isFailure())
 			return pathCreationResult;
 	}
 

--- a/comp/io/src/qx-filestreamreader.cpp
+++ b/comp/io/src/qx-filestreamreader.cpp
@@ -169,9 +169,9 @@ QFile* FileStreamReader::file() { return mSourceFile; }
 /*!
  *  Returns @c true if the stream's current status indicates that an error has occurred; otherwise, returns @c false.
  *
- *  Equivalent to `!status().wasSuccessful()`.
+ *  Equivalent to `status().isFailure()`.
  */
-bool FileStreamReader::hasError() { return status().wasSuccessful(); }
+bool FileStreamReader::hasError() { return status().isFailure(); }
 
 /*!
  *  Opens the file associated with the file stream reader and returns an operation report.

--- a/comp/io/src/qx-filestreamwriter.cpp
+++ b/comp/io/src/qx-filestreamwriter.cpp
@@ -148,9 +148,9 @@ QFile* FileStreamWriter::file() { return mTargetFile; }
 /*!
  *  Returns @c true if the stream's current status indicates that an error has occurred; otherwise, returns @c false.
  *
- *  Equivalent to `!status().wasSuccessful()`.
+ *  Equivalent to `status().isFailure()`.
  */
-bool FileStreamWriter::hasError() { return status().wasSuccessful(); }
+bool FileStreamWriter::hasError() { return status().isFailure(); }
 
 /*!
  *  Opens the file associated with the file stream writer and returns an operation report.
@@ -163,7 +163,7 @@ IoOpReport FileStreamWriter::openFile()
     // Perform write preparations
     bool fileExists;
     IoOpReport prepResult = writePrep(fileExists, mTargetFile, mWriteOptions);
-    if(!prepResult.wasSuccessful())
+    if(prepResult.isFailure())
         return prepResult;
 
     // Attempt to open file

--- a/comp/io/src/qx-ioopreport.cpp
+++ b/comp/io/src/qx-ioopreport.cpp
@@ -185,13 +185,17 @@ namespace Qx
 //Public:
 /*!
  *  Creates a null IO operation report.
+ *
+ *  @sa isNull() and isFailure().
  */
 IoOpReport::IoOpReport() :
     mNull(true),
     mOperation(IO_OP_ENUMERATE),
     mResult(IO_SUCCESS),
     mTargetType(IO_FILE),
-    mTarget(QString())
+    mTarget(),
+    mOutcome(),
+    mOutcomeInfo()
 {}
 
 /*!
@@ -339,9 +343,11 @@ QString IoOpReport::outcome() const { return mOutcome; }
 QString IoOpReport::outcomeInfo() const { return mOutcomeInfo; }
 
 /*!
- *  Returns @c true if the operation was successful; otherwise returns @c false.
+ *  Returns @c true if the described operation failed; otherwise returns @c false.
+ *
+ *  A null IoOpReport is not considered to describe a failure.
  */
-bool IoOpReport::wasSuccessful() const { return mResult == IO_SUCCESS; }
+bool IoOpReport::isFailure() const { return mResult != IO_SUCCESS; }
 
 /*!
  *  Returns @c true if the report is null; otherwise returns @c false.
@@ -357,7 +363,7 @@ bool IoOpReport::isNull() const { return mNull; }
  */
 GenericError IoOpReport::toGenericError() const
 {
-    if(wasSuccessful())
+    if(isFailure())
         return GenericError();
     else
         return GenericError(GenericError::Error, outcome(), outcomeInfo());

--- a/comp/io/src/qx-textstreamreader.cpp
+++ b/comp/io/src/qx-textstreamreader.cpp
@@ -251,9 +251,9 @@ IoOpReport TextStreamReader::status() const
 /*!
  *  Returns @c true if the stream's current status indicates that an error has occurred; otherwise, returns @c false.
  *
- *  Equivalent to `!status().wasSuccessful()`.
+ *  Equivalent to `status().isFailure()`.
  */
-bool TextStreamReader::hasError() { return status().wasSuccessful(); }
+bool TextStreamReader::hasError() { return status().isFailure(); }
 
 /*!
  *  Opens the text file associated with the text stream reader and returns an operation report.

--- a/comp/io/src/qx-textstreamwriter.cpp
+++ b/comp/io/src/qx-textstreamwriter.cpp
@@ -208,9 +208,9 @@ IoOpReport TextStreamWriter::status() const
 /*!
  *  Returns @c true if the stream's current status indicates that an error has occurred; otherwise, returns @c false.
  *
- *  Equivalent to `!status().wasSuccessful()`.
+ *  Equivalent to `status().isFailure()`.
  */
-bool TextStreamWriter::hasError() { return status().wasSuccessful(); }
+bool TextStreamWriter::hasError() { return status().isFailure(); }
 
 /*!
  *  Writes @a line to the stream followed by a line break and returns the streams @ref status.
@@ -274,14 +274,14 @@ IoOpReport TextStreamWriter::openFile()
     // Perform write preparations
     bool existingFile;
     IoOpReport prepResult = writePrep(existingFile, mTargetFile, mWriteOptions);
-    if(!prepResult.wasSuccessful())
+    if(prepResult.isFailure())
         return prepResult;
 
     // If file exists and mode is append, test if it starts on a new line
     if(mWriteMode == Append && existingFile)
     {
         IoOpReport inspectResult = textFileEndsWithNewline(mAtLineStart, *mTargetFile);
-        if(!inspectResult.wasSuccessful())
+        if(inspectResult.isFailure())
             return IoOpReport(IO_OP_WRITE, inspectResult.result(), *mTargetFile);
     }
 

--- a/comp/network/src/qx-downloadmanager.cpp
+++ b/comp/network/src/qx-downloadmanager.cpp
@@ -312,7 +312,7 @@ void AsyncDownloadManager::startDownload(DownloadTask task)
 
     // Open file
     IoOpReport streamOpen = fileWriter->openFile();
-    if(!streamOpen.wasSuccessful())
+    if(streamOpen.isFailure())
     {
         forceFinishProgress(task);
         recordFinishedDownload(DownloadOpReport::failedDownload(task, streamOpen.outcome() + ": " + streamOpen.outcomeInfo()));
@@ -655,7 +655,7 @@ void AsyncDownloadManager::readyReadHandler()
     std::shared_ptr<FileStreamWriter> writer = mActiveWriters[senderNetworkReply];
     IoOpReport wr = writer->writeRawData(senderNetworkReply->readAll());
 
-    if(!wr.wasSuccessful())
+    if(wr.isFailure())
     {
         // Close and delete file, finished handler will use this info to create correct report
         writer->file()->remove(); // Closes file first

--- a/comp/windows/src/qx-common-windows.cpp
+++ b/comp/windows/src/qx-common-windows.cpp
@@ -267,7 +267,7 @@ bool enforceSingleInstance()
     QFile selfEXE(QCoreApplication::applicationFilePath());
     QString selfHash;
 
-    if(!calculateFileChecksum(selfHash, selfEXE, QCryptographicHash::Sha256).wasSuccessful())
+    if(calculateFileChecksum(selfHash, selfEXE, QCryptographicHash::Sha256).isFailure())
         return false;
 
     // Attempt to create unique mutex


### PR DESCRIPTION
Now the function returns a boolean from the perspective of looking for
an error by default, instead of requiring a negation to check for an
error.

This way a null IoOpReport can reasonable be seen as neither a success
nor a failure, and instead used in contexts where nothing has occured
(i.e. Qx streamers).

To clarify, calling `.isFailure()` on a null IoOpReport returning
`false` is reasonable given the above, where as before checking !
wasSuccessful more so gave the implication that the op failed outright.
It's reasonable to consider both successful and null reports as "non-
failures" under the new perspective.