### PR TITLE
Improve IO stream file and status handling

### DIFF
--- a/comp/io/include/qx/io/qx-filestreamwriter.h
+++ b/comp/io/include/qx/io/qx-filestreamwriter.h
@@ -13,18 +13,34 @@ namespace Qx
 	
 class FileStreamWriter // Specialized wrapper for QDataStream
 {
+//-Class Variables------------------------------------------------------------------------------------------------
+private:
+    static inline const IoOpReport NULL_FILE_REPORT = IoOpReport(IO_OP_WRITE, IO_ERR_NULL, static_cast<QFile*>(nullptr));
+
 //-Instance Variables------------------------------------------------------------------------------------------------
 private:
+    QFile* mFile;
     QDataStream mStreamWriter;
-    QFile* mTargetFile;
     WriteMode mWriteMode;
     WriteOptions mWriteOptions;
+    IoOpReport mStatus;
 
 //-Constructor-------------------------------------------------------------------------------------------------------
 public:
-    FileStreamWriter(QFile* file, WriteMode writeMode = Append, WriteOptions writeOptions = NoWriteOptions);
+    FileStreamWriter(WriteMode writeMode = Append, WriteOptions writeOptions = NoWriteOptions);
+    FileStreamWriter(const QString& filePath, WriteMode writeMode = Append, WriteOptions writeOptions = NoWriteOptions);
+
+//-Destructor-------------------------------------------------------------------------------------------------------
+public:
+    ~FileStreamWriter();
 
 //-Instance Functions------------------------------------------------------------------------------------------------
+private:
+    IoOpReport statusFromNative();
+    IoOpReport preWriteErrorCheck();
+    void setFile(const QString& filePath);
+    void unsetFile();
+
 public:
     // Stock functions
     QDataStream::ByteOrder byteOrder() const;
@@ -37,14 +53,27 @@ public:
 
     template<typename T>
         requires defines_left_shift_for<QDataStream, T>
-    FileStreamWriter& operator<<(T d) { mStreamWriter << d; return *this; }
+    FileStreamWriter& operator<<(T d)
+    {
+        IoOpReport check = preWriteErrorCheck();
 
-    QFile* file();
+        if(!check.isFailure())
+        {
+            mStreamWriter << d;
+            mStatus = statusFromNative();
+        }
+
+        return *this;
+    }
+
+    QString filePath() const;
+    void setFilePath(const QString& filePath);
 
     // New functions
-    bool hasError();
+    bool hasError() const;
     IoOpReport openFile();
     void closeFile();
+    bool fileIsOpen() const;
 };
 
 }

--- a/comp/io/include/qx/io/qx-textstreamreader.h
+++ b/comp/io/include/qx/io/qx-textstreamreader.h
@@ -14,16 +14,32 @@ namespace Qx
 
 class TextStreamReader
 {
+//-Class Variables------------------------------------------------------------------------------------------------
+private:
+    static inline const IoOpReport NULL_FILE_REPORT = IoOpReport(IO_OP_READ, IO_ERR_NULL, static_cast<QFile*>(nullptr));
+
 //-Instance Variables------------------------------------------------------------------------------------------------
 private:
+    QFile* mFile;
     QTextStream mStreamReader;
-    QFile* mSourceFile;
+    IoOpReport mStatus;
 
 //-Constructor-------------------------------------------------------------------------------------------------------
 public:
-    TextStreamReader(QFile* file);
+    TextStreamReader();
+    TextStreamReader(const QString& filePath);
+
+//-Destructor-------------------------------------------------------------------------------------------------------
+public:
+    ~TextStreamReader();
 
 //-Instance Functions------------------------------------------------------------------------------------------------
+private:
+    IoOpReport statusFromNative();
+    IoOpReport preReadErrorCheck();
+    void setFile(const QString& filePath);
+    void unsetFile();
+
 public:
     // Stock functions
     bool atEnd() const;
@@ -49,12 +65,27 @@ public:
 
     template<typename T>
         requires defines_right_shift_for<QTextStream, T&>
-    TextStreamReader& operator>>(T& d) { mStreamReader >> d; return *this; }
+    TextStreamReader& operator>>(T& d)
+    {
+        IoOpReport check = preReadErrorCheck();
+
+        if(!check.isFailure())
+        {
+            mStreamReader >> d;
+            mStatus = statusFromNative();
+        }
+
+        return *this;
+    }
+
+    QString filePath() const;
+    void setFilePath(const QString& filePath);
 
     // New functions
-    bool hasError();
+    bool hasError() const;
     IoOpReport openFile();
     void closeFile();
+    bool fileIsOpen() const;
 };
 
 }

--- a/comp/io/src/qx-textstreamwriter.cpp
+++ b/comp/io/src/qx-textstreamwriter.cpp
@@ -20,20 +20,49 @@ namespace Qx
  *
  *  Most member functions are the same or slightly modified versions of those from QTextStream.
  *
+ *  The file on which to operate is specified as a path and the underlying handle is managed by the stream.
+ *
  *  @sa TextStreamReader and FileStreamWriter
  */
 
 //-Constructor---------------------------------------------------------------------------------------------------
 //Public:
+
 /*!
- *  Constructs a text stream writer that is linked to @a file, configured with @a writeMode and @a writeOptions.
+ *  Constructs a text stream writer that is configured with @a writeMode and @a writeOptions.
+ *
+ *  No file is initially set.
  *
  *  @note The following WriteMode values are not supported with this class and will be remapped as shown:
  *  @li @c WriteMode::Insert -> @c WriteMode::Append
  *  @li @c WriteMode::Overwrite -> @c WriteMode::Truncate
+ *
+ *  @sa setFilePath().
  */
-TextStreamWriter::TextStreamWriter(QFile* file, WriteMode writeMode, WriteOptions writeOptions) :
-    mTargetFile(file),
+TextStreamWriter::TextStreamWriter(WriteMode writeMode, WriteOptions writeOptions) :
+    mFile(nullptr),
+    mWriteMode(writeMode),
+    mWriteOptions(writeOptions),
+    mAtLineStart(true)
+{
+    // Map unsupported modes to supported ones
+    if(mWriteMode == Insert)
+        mWriteMode = Append;
+    else if(mWriteMode == Overwrite)
+        mWriteMode = Truncate;
+}
+
+/*!
+ *  Constructs a text stream writer that is linked to the file at @a filePath, configured with @a writeMode
+ *  and @a writeOptions.
+ *
+ *  @note The following WriteMode values are not supported with this class and will be remapped as shown:
+ *  @li @c WriteMode::Insert -> @c WriteMode::Append
+ *  @li @c WriteMode::Overwrite -> @c WriteMode::Truncate
+ *
+ *  @sa filePath() and setFilePath().
+ */
+TextStreamWriter::TextStreamWriter(const QString& filePath, WriteMode writeMode, WriteOptions writeOptions) :
     mWriteMode(writeMode),
     mWriteOptions(writeOptions),
     mAtLineStart(true)
@@ -44,11 +73,59 @@ TextStreamWriter::TextStreamWriter(QFile* file, WriteMode writeMode, WriteOption
     else if(mWriteMode == Overwrite)
         mWriteMode = Truncate;
 
-    if(mTargetFile->isOpen())
-        mTargetFile->close(); // Must open using member function for proper behavior
+    setFile(filePath);
 }
 
+//-Destructor-------------------------------------------------------------------------------------------------------
+//Public:
+/*!
+ *  Destroys the text stream writer, along with closing and deleting the underlying file, if present.
+ */
+TextStreamWriter::~TextStreamWriter() { unsetFile(); }
+
+
 //-Instance Functions--------------------------------------------------------------------------------------------
+//Private:
+IoOpReport TextStreamWriter::statusFromNative()
+{
+    return IoOpReport(IoOpType::IO_OP_WRITE, TXT_STRM_STAT_MAP.value(mStreamWriter.status()), mFile);
+}
+
+IoOpReport TextStreamWriter::preWriteErrorCheck()
+{
+    if(hasError())
+        return mStatus;
+    else if(!mFile)
+    {
+        mStatus = NULL_FILE_REPORT;
+        return mStatus;
+    }
+    else if(!mFile->isOpen())
+    {
+        mStatus = IoOpReport(IO_OP_WRITE, IO_ERR_FILE_NOT_OPEN, mFile);
+        return mStatus;
+    }
+    else
+        return IoOpReport();
+}
+
+void TextStreamWriter::setFile(const QString& filePath)
+{
+    if(!filePath.isNull())
+    {
+        mFile = new QFile(filePath);
+        mStreamWriter.setDevice(mFile);
+    }
+}
+
+void TextStreamWriter::unsetFile()
+{
+    if(mFile)
+        delete mFile;
+    mFile = nullptr;
+    mStreamWriter.setDevice(mFile);
+}
+
 //Public:
 /*!
  *  Returns the encoding that is current assigned to the stream.
@@ -117,12 +194,19 @@ int TextStreamWriter::realNumberPrecision() const { return mStreamWriter.realNum
 void TextStreamWriter::reset() { return mStreamWriter.reset(); }
 
 /*!
- *  Resets the status of the text stream.
+ *  Resets the status of the text stream reader.
+ *
+ *  @note
+ *  If an error occurs while writing the stream will ignore all further write attempts and hold its
+ *  current status until this function is called.
  *
  *  @sa status().
  */
-void TextStreamWriter::resetStatus() { return mStreamWriter.resetStatus(); }
-
+void TextStreamWriter::resetStatus()
+{
+    mStatus = IoOpReport();
+    mStreamWriter.resetStatus();
+}
 /*!
  *  Sets the encoding for this stream to @a encoding. The encoding is used for any data that is written. By default,
  *  QStringConverter::Utf8 is used.
@@ -189,12 +273,10 @@ void TextStreamWriter::setRealNumberPrecision(int precision) { mStreamWriter.set
 /*!
  *  Returns the status of the text stream writer.
  *
- *  @sa resetStatus().
+ *  The status is a report of the last write operation performed by TextStreamWriter. If no write operation has
+ *  been performed since the stream was constructed or resetStatus() was last called the report will be null.
  */
-IoOpReport TextStreamWriter::status() const
-{
-    return IoOpReport(IoOpType::IO_OP_WRITE, TXT_STRM_STAT_MAP.value(mStreamWriter.status()), *mTargetFile);
-}
+IoOpReport TextStreamWriter::status() const { return mStatus; }
 
 /*!
  *  @fn template<typename T> requires defines_left_shift_for<QTextStream, T> TextStreamWriter& TextStreamWriter::operator<<(T d)
@@ -210,7 +292,7 @@ IoOpReport TextStreamWriter::status() const
  *
  *  Equivalent to `status().isFailure()`.
  */
-bool TextStreamWriter::hasError() { return status().isFailure(); }
+bool TextStreamWriter::hasError() const { return status().isFailure(); }
 
 /*!
  *  Writes @a line to the stream followed by a line break and returns the streams @ref status.
@@ -220,25 +302,26 @@ bool TextStreamWriter::hasError() { return status().isFailure(); }
  */
 IoOpReport TextStreamWriter::writeLine(QString line, bool ensureLineStart)
 {
-    if(mTargetFile->isOpen())
-    {
-        // Ensure line start if requested
-        if(ensureLineStart && !mAtLineStart)
-            mStreamWriter << ENDL;
+    IoOpReport check = preWriteErrorCheck();
 
-        // Write line to file
-        mStreamWriter << line << ENDL;
-        if(mWriteOptions.testFlag(Unbuffered))
-            mStreamWriter.flush();
+    if(check.isFailure())
+        return check;
 
-        // Mark that text will end at line start
-        mAtLineStart = true;
+    // Ensure line start if requested
+    if(ensureLineStart && !mAtLineStart)
+        mStreamWriter << ENDL;
 
-        // Return stream status
-        return status();
-    }
-    else
-        return IoOpReport(IO_OP_WRITE, IO_ERR_FILE_NOT_OPEN, *mTargetFile);
+    // Write line to file
+    mStreamWriter << line << ENDL;
+    if(mWriteOptions.testFlag(Unbuffered))
+        mStreamWriter.flush();
+
+    // Mark that text will end at line start
+    mAtLineStart = true;
+
+    // Set and return stream status
+    mStatus = statusFromNative();
+    return mStatus;
 }
 
 /*!
@@ -246,43 +329,66 @@ IoOpReport TextStreamWriter::writeLine(QString line, bool ensureLineStart)
  */
 IoOpReport TextStreamWriter::writeText(QString text)
 {
-    if(mTargetFile->isOpen())
-    {
-        // Check if data will end at line start
-        mAtLineStart = text.back() == ENDL;
+    IoOpReport check = preWriteErrorCheck();
 
-        // Write text to file
-        mStreamWriter << text;
-        if(mWriteOptions.testFlag(Unbuffered))
-            mStreamWriter.flush();
+    if(check.isFailure())
+        return check;
 
-        // Return stream status
-        return IoOpReport(IO_OP_WRITE, TXT_STRM_STAT_MAP.value(mStreamWriter.status()), *mTargetFile);
-    }
-    else
-        return IoOpReport(IO_OP_WRITE, IO_ERR_FILE_NOT_OPEN, *mTargetFile);
+    // Check if data will end at line start
+    mAtLineStart = text.back() == ENDL;
+
+    // Write text to file
+    mStreamWriter << text;
+    if(mWriteOptions.testFlag(Unbuffered))
+        mStreamWriter.flush();
+
+    // Set and return stream status
+    mStatus = statusFromNative();
+    return mStatus;
 }
 
 /*!
- *  Opens the text file associated with the text stream writer and returns an operation report.
+ *  Links the stream to the file at @a filePath, which can be a null QString to unset the current
+ *  file. If a file was already set to the stream, it will be closed as it is replaced.
  *
- *  This function must be called before any data is written, unless the file is already open
- *  in a mode that supports writing before the stream was constructed.
+ *  The file must be opened through the stream before it can be used.
+ *
+ *  @sa filePath() and openFile().
+ */
+void TextStreamWriter::setFilePath(const QString& filePath)
+{
+    unsetFile();
+    setFile(filePath);
+}
+
+/*!
+ *  Returns the path of the file associated with the stream, if present.
+ *
+ *  If no file is assigned the path will be null.
+ *
+ *  @sa setFilePath().
+ */
+QString TextStreamWriter::filePath() const { return mFile ? mFile->fileName() : QString(); }
+
+/*!
+ *  Opens the file associated with the text stream writer and returns an operation report.
+ *
+ *  This function must be called before any data is written after a file is assigned to the stream.
  */
 IoOpReport TextStreamWriter::openFile()
 {
     // Perform write preparations
     bool existingFile;
-    IoOpReport prepResult = writePrep(existingFile, mTargetFile, mWriteOptions);
+    IoOpReport prepResult = writePrep(existingFile, mFile, mWriteOptions);
     if(prepResult.isFailure())
         return prepResult;
 
     // If file exists and mode is append, test if it starts on a new line
     if(mWriteMode == Append && existingFile)
     {
-        IoOpReport inspectResult = textFileEndsWithNewline(mAtLineStart, *mTargetFile);
+        IoOpReport inspectResult = textFileEndsWithNewline(mAtLineStart, *mFile);
         if(inspectResult.isFailure())
-            return IoOpReport(IO_OP_WRITE, inspectResult.result(), *mTargetFile);
+            return IoOpReport(IO_OP_WRITE, inspectResult.result(), mFile);
     }
 
     // Attempt to open file
@@ -291,30 +397,34 @@ IoOpReport TextStreamWriter::openFile()
     if(mWriteOptions.testFlag(Unbuffered))
         om |= QIODevice::Unbuffered;
 
-    IoOpResultType openResult = parsedOpen(*mTargetFile, om);
+    IoOpResultType openResult = parsedOpen(*mFile, om);
     if(openResult != IO_SUCCESS)
-        return IoOpReport(IO_OP_WRITE, openResult, *mTargetFile);
-
-    // Set data stream IO device
-    mStreamWriter.setDevice(mTargetFile);
+        return IoOpReport(IO_OP_WRITE, openResult, mFile);
 
     // Write line break if needed
     if(!mAtLineStart && mWriteOptions.testFlag(EnsureBreak))
     {
         mStreamWriter << ENDL;
         mAtLineStart = true;
+        mStatus = statusFromNative();
+        return mStatus;
     }
-
-    // Return no error
-    return IoOpReport(IO_OP_WRITE, IO_SUCCESS, *mTargetFile);
+    else // Return no error
+        return IoOpReport(IO_OP_WRITE, IO_SUCCESS, mFile);
 }
 
 /*!
- *  Closes the text file associated with the text stream writer.
- *
- *  This function should be called when the stream is no longer needed, unless the file should
- *  remain open for use elsewhere.
+ *  Closes the file associated with the text stream writer, if present.
  */
-void TextStreamWriter::closeFile() { mTargetFile->close(); }
+void TextStreamWriter::closeFile()
+{
+    if(mFile)
+        mFile->close();
+}
+
+/*!
+ * Returns @c true if the file managed by the stream is open; otherwise, returns @c false.
+ */
+bool TextStreamWriter::fileIsOpen() const { return mFile && mFile->isOpen(); }
 
 }

--- a/comp/network/src/qx-downloadmanager.cpp
+++ b/comp/network/src/qx-downloadmanager.cpp
@@ -301,14 +301,11 @@ void AsyncDownloadManager::pushDownloadsUntilFinished()
 
 void AsyncDownloadManager::startDownload(DownloadTask task)
 {
-    // Create file handle
-    QFile* file = new QFile(task.dest, this); // Parent constructor ensures deletion when 'this' is deleted
-
     // Create stream writer
     WriteOptions wo = WriteOption::CreatePath;
     if(!mOverwrite)
         wo |= WriteOption::NewOnly;
-    std::shared_ptr<FileStreamWriter> fileWriter = std::make_shared<FileStreamWriter>(file, WriteMode::Truncate, wo);
+    std::shared_ptr<FileStreamWriter> fileWriter = std::make_shared<FileStreamWriter>(task.dest, WriteMode::Truncate, wo);
 
     // Open file
     IoOpReport streamOpen = fileWriter->openFile();
@@ -658,7 +655,8 @@ void AsyncDownloadManager::readyReadHandler()
     if(wr.isFailure())
     {
         // Close and delete file, finished handler will use this info to create correct report
-        writer->file()->remove(); // Closes file first
+        writer->closeFile();
+        QFile::remove(writer->filePath());
 
         if(mStopOnError)
             stopOnError();
@@ -776,7 +774,7 @@ void AsyncDownloadManager::downloadFinishedHandler(QNetworkReply* reply)
         QNetworkReply::NetworkError error = reply->error();
         bool abortLike = error == QNetworkReply::OperationCanceledError;
         bool timeout = abortLike && mStatus != Status::StoppingOnError && mStatus != Status::Aborting;
-        bool writeError = abortLike && !fileWriter->file()->isOpen();
+        bool writeError = abortLike && !fileWriter->fileIsOpen();
 
         // Handle this error
         forceFinishProgress(task);
@@ -809,7 +807,6 @@ void AsyncDownloadManager::downloadFinishedHandler(QNetworkReply* reply)
 
     // Cleanup writer
     fileWriter->closeFile();
-    delete fileWriter->file();
 
     // Remove from active writers
     mActiveWriters.remove(reply);


### PR DESCRIPTION
- File now specified as a path, the stream manages the QFile handle
itself (required to enforce proper open mode and write settings in
writing streams)

- The streams can now been reassigned to a new file

- Stream status is now the outcome of the last op, or a null report if
none performed yet. If an op fails, that status is held and future
operations are ignored until the status is reset