### PR TITLE
Add processIsElevated() to qx-windows

### DIFF
--- a/comp/windows/include/qx/windows/qx-common-windows.h
+++ b/comp/windows/include/qx/windows/qx-common-windows.h
@@ -48,8 +48,13 @@ QList<DWORD> processThreadIds(DWORD processId);
  * See https://docs.microsoft.com/en-us/windows/win32/psapi/module-information
  */
 
+// TODO: error check these functions like processIsElevated
 bool processIsRunning(QString processName);
 bool processIsRunning(DWORD processID);
+
+Qx::GenericError processIsElevated(bool& elevated);
+Qx::GenericError processIsElevated(bool& elevated, HANDLE processHandle);
+Qx::GenericError processIsElevated(bool& elevated, DWORD processId);
 
 bool enforceSingleInstance();
 bool enforceSingleInstance(QString uniqueAppId);

--- a/comp/windows/include/qx/windows/qx-windefs.h
+++ b/comp/windows/include/qx/windows/qx-windefs.h
@@ -5,5 +5,6 @@ typedef unsigned long DWORD;
 typedef long LONG;
 typedef LONG HRESULT;
 typedef LONG NTSTATUS;
+typedef void* HANDLE;
 
 #endif // QX_WINDEFS_H

--- a/comp/windows/src/qx-windefs.dox
+++ b/comp/windows/src/qx-windefs.dox
@@ -26,9 +26,20 @@
 /*!
  *  @typedef HRESULT
  *  Same as @ref LONG
+ *
+ *  Used to hold the results of Win32 related operations.
  */
 
 /*!
  *  @typedef NTSTATUS
  *  Same as @ref LONG
+ *
+ *  Used to hold the results of WinNT related operations
+ */
+
+/*!
+ *  @typedef HANDLE
+ *  A void pointer.
+ *
+ *  Used as a reference to a Windows object.
  */


### PR DESCRIPTION
Multiple overloads to check if a given process is running with UAC elevation (or otherwise admin permissions).