### PR TITLE
Fix roundToNearestMultiple() rounding bias, add ceil/floor for multiples

### DIFF
--- a/comp/core/include/qx/core/qx-algorithm.h
+++ b/comp/core/include/qx/core/qx-algorithm.h
@@ -169,22 +169,57 @@ T constrainedDiv(T a, T b, T max = std::numeric_limits<T>::max())
 
 template<typename T>
     requires std::integral<T>
-T roundToNearestMultiple(T num, T mult)
+T ceilNearestMultiple(T num, T mult)
 {
     // Ensure mult is positive
     mult = Qx::abs(mult);
 
-	if(mult == 0)
-		return 0;
+    if(mult == 0)
+        return 0;
 
-	if(mult == 1)
-		return num;
+    if(mult == 1 || mult == num)
+        return num;
 
-    T towardsZero = (num / mult) * mult;
-    T awayFromZero = num < 0 ? constrainedSub(towardsZero, mult) : constrainedAdd(towardsZero, mult);
+    if(num < 0)
+        return (num / mult) * mult;
+    else
+    {
+        T previousMultiple = (num / mult) * mult;
+        return previousMultiple == num ? num : constrainedAdd(previousMultiple, mult);
+    }
+}
 
-	// Return of closest the two directions
-    return (distance(towardsZero, num) <= distance(awayFromZero, num)) ? towardsZero : awayFromZero;
+template<typename T>
+    requires std::integral<T>
+T floorNearestMultiple(T num, T mult)
+{
+    // Ensure mult is positive
+    mult = Qx::abs(mult);
+
+    if(mult == 0)
+        return 0;
+
+    if(mult == 1 || mult == num)
+        return num;
+
+    if(num > 0)
+        return (num / mult) * mult;
+    else
+    {
+        T nextMultiple = (num / mult) * mult;
+        return nextMultiple == num ? num : constrainedSub(nextMultiple, mult);
+    }
+}
+
+template<typename T>
+    requires std::integral<T>
+T roundToNearestMultiple(T num, T mult)
+{
+    T above = ceilNearestMultiple(num, mult);
+    T below = floorNearestMultiple(num, mult);
+
+    // Return of closest the two directions
+    return above - num <= num - below ? above : below;
 }
 
 template <typename T>

--- a/comp/core/src/qx-algorithm.cpp
+++ b/comp/core/src/qx-algorithm.cpp
@@ -144,6 +144,24 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
+ *  @fn template<typename T> requires std::integral<T> static T ceilNearestMultiple(T num, T mult)
+ *
+ *  Returns the next (i.e. higher) multiple of @a mult after @a num, or @a num if it is already
+ *  a multiple of @a mult.
+ *
+ *  The sign of the result will always be the same sign as @a num, regardless of the sign of @a mult.
+ */
+
+/*!
+ *  @fn template<typename T> requires std::integral<T> static T floorNearestMultiple(T num, T mult)
+ *
+ *  Returns the previous (i.e. lower) multiple of @a mult after @a num, or @a num if it is already
+ *  a multiple of @a mult.
+ *
+ *  The sign of the result will always be the same sign as @a num, regardless of the sign of @a mult.
+ */
+
+/*!
  *  @fn template<typename T> requires std::integral<T> static T roundToNearestMultiple(T num, T mult)
  *
  *  Returns the multiple of @a mult that @a num is closest to.
@@ -154,13 +172,15 @@ unsigned long long abs(unsigned long long n) { return n; }
 /*!
  *  @fn template <typename T> requires std::integral<T> static T ceilPowOfTwo(T num)
  *
- *  Returns the next (i.e. higher) power of two after @a num.
+ *  Returns the next (i.e. higher) power of two after @a num, or @a num if it is
+ *  already a power of two.
  */
 
 /*!
  *  @fn template <typename T> requires std::integral<T> static T floorPowOfTwo(T num)
  *
- *  Returns the previous (i.e. lower) power of two before @a num.
+ *  Returns the previous (i.e. lower) power of two before @a num, or @a num if it is
+ *  already a power of two.
  */
 
 /*!


### PR DESCRIPTION
When roundToNearestMultiple() was given a number equidistant from the
next and previous multiples it would always select the value closer to
zero. This has been corrected to be more standard in that
roundToNearestMultiple() will now always prefer to round up.

Added ceilNearestMultiple() and floorNearestMultiple().