### PR TITLE
Add any_of concept for any of a type list

### DIFF
--- a/comp/utility/include/qx/utility/qx-concepts.h
+++ b/comp/utility/include/qx/utility/qx-concepts.h
@@ -488,6 +488,10 @@ concept traverseable = std::bidirectional_iterator<typename K::const_iterator> &
 template<class K, typename T>
 concept static_castable_to = requires(K klass) {{ static_cast<T>(klass) };};
 
+// Grouping
+template<class K, class ... L>
+concept any_of = (std::same_as<K, L> || ...);
+
 }
 
 #endif // QX_CONCEPTS_H


### PR DESCRIPTION
May change name later to not confuse with std::any_of, though couldn't
think of a good one yet.

one_of is used by boost, any_one sounds weird.