### PR TITLE
Fix package config bugs

### DIFF
--- a/cmake/module/Qx/ComponentHelper.cmake
+++ b/cmake/module/Qx/ComponentHelper.cmake
@@ -179,9 +179,9 @@ macro(register_qx_component)
     )
 
     # Install public headers
-    install(DIRECTORY include/${PROJECT_NAME_LC}
+    install(DIRECTORY include/
         COMPONENT ${COMPONENT_TARGET_NAME}
-        DESTINATION "include/${COMPONENT_NAME_LC}"
+        DESTINATION "include/${COMPONENT_NAME_LC}/"
         ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
     )
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME_LC}/${COMPONENT_NAME_LC}.h"


### PR DESCRIPTION
The first fix is:
"Fix some contents of component include dirs not being installed"
which fixes qx_windows.h not being copied to the install directory during the install step.

Additionally, the commit in dev that proceeds this one is also thematically part of this PR. It fixes the missing set of the uppercase component name within ComponentHelper.cmake/register_qx_component() that caused the library's import configuration to fail when trying to import more than one component.