### PR TITLE
Remove redundant portions of fn signatures in documentation

### DIFF
--- a/lib/core/src/qx-algorithm.cpp
+++ b/lib/core/src/qx-algorithm.cpp
@@ -51,7 +51,7 @@ long long abs (long long n) { return std::abs(n); }
 unsigned long long abs(unsigned long long n) { return n; }
 
 /*!
- *  @fn template<typename T> requires std::integral<T> T length(T start, T end)
+ *  @fn T length(T start, T end)
  *
  *  Computes the length of, or alternatively the number of elements in, the range [@a start,  @a end].
  *
@@ -59,31 +59,31 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template<typename T> requires arithmetic<T> static bool isOdd(T num)
+ *  @fn bool isOdd(T num)
  *
  *  Returns @c true if @a num is odd; otherwise returns @c false.
  */
 
 /*!
- *  @fn template<typename T> requires arithmetic<T> static bool isEven(T num)
+ *  @fn bool isEven(T num)
  *
  *  Returns @c true if there are duplicate elements in the range [@a first, @a last); otherwise returns @c false.
  */
 
 /*!
- *  @fn template <class InputIt> requires std::input_iterator<InputIt> && std::equality_comparable<InputIt> bool containsDuplicates(InputIt begin, InputIt end)
+ *  @fn bool containsDuplicates(InputIt begin, InputIt end)
  *
  *  Returns @c true if @a num is even; otherwise returns @c false.
  */
 
 /*!
- *  @fn template<typename T> requires arithmetic<T> static T distance(T x, T y)
+ *  @fn T distance(T x, T y)
  *
  *  Returns the absolute distance between @a x and @a y.
  */
 
 /*!
- *  @fn template <typename T> requires std::signed_integral<T> static T constrainedAdd(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
+ *  @fn T constrainedAdd(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
  *
  *  Returns the result of adding signed integers @a a and @a b, bounded between @a min and @a max inclusive.
  *
@@ -91,14 +91,14 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template <typename T> requires std::unsigned_integral<T> static T constrainedAdd(T a, T b, T max = std::numeric_limits<T>::max())
+ *  @fn T constrainedAdd(T a, T b, T max = std::numeric_limits<T>::max())
  *  Returns the result of adding unsigned integers @a a and @a b, bounded between 0 and @a max inclusive.
  *
  *  The default arguments of this function make it useful for performing addition that is safe from overflow.
  */
 
 /*!
- *  @fn template <typename T> requires std::signed_integral<T> static T constrainedSub(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
+ *  @fn T constrainedSub(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
  *
  *  Returns the result of subtracting signed integers @a a and @a b, bounded between @a min and @a max inclusive.
  *
@@ -106,7 +106,7 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template <typename T> requires std::unsigned_integral<T>static T constrainedSub(T a, T b, T min = 0)
+ *  @fn T constrainedSub(T a, T b, T min = 0)
  *
  *  Returns the result of subtracting unsigned integers @a a and @a b, bounded between @a min and @c "std::numeric_limits<T>::max()" inclusive.
  *
@@ -114,7 +114,7 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template<typename T> requires std::signed_integral<T> static T constrainedMult(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
+ *  @fn T constrainedMult(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
  *
  *  Returns the result of multiplying signed integers @a a and @a b, bounded between @a min and @a max inclusive.
  *
@@ -122,7 +122,7 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template<typename T> requires std::unsigned_integral<T> static T constrainedMult(T a, T b, T max = std::numeric_limits<T>::max())
+ *  @fn T constrainedMult(T a, T b, T max = std::numeric_limits<T>::max())
  *
  *  Returns the result of multiplying unsigned integers @a a and @a b, bounded between 0 and @a max inclusive.
  *
@@ -130,7 +130,7 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template<typename T> requires std::signed_integral<T> static T constrainedDiv(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
+ *  @fn T constrainedDiv(T a, T b, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
  *
  *  Returns the result of dividing signed integer @a a by signed integer @a b, bounded between @a min and @a max inclusive.
  *
@@ -138,13 +138,13 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template<typename T> requires std::unsigned_integral<T> static T constrainedDiv(T a, T b, T max = std::numeric_limits<T>::max())
+ *  @fn T constrainedDiv(T a, T b, T max = std::numeric_limits<T>::max())
  *
  *  Returns the result of dividing unsigned integer @a a by signed integer @a b, bounded between 0 and @a max inclusive.
  */
 
 /*!
- *  @fn template<typename T> requires std::integral<T> static T ceilNearestMultiple(T num, T mult)
+ *  @fn T ceilNearestMultiple(T num, T mult)
  *
  *  Returns the next (i.e. higher) multiple of @a mult after @a num, or @a num if it is already
  *  a multiple of @a mult.
@@ -153,7 +153,7 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template<typename T> requires std::integral<T> static T floorNearestMultiple(T num, T mult)
+ *  @fn T floorNearestMultiple(T num, T mult)
  *
  *  Returns the previous (i.e. lower) multiple of @a mult after @a num, or @a num if it is already
  *  a multiple of @a mult.
@@ -162,7 +162,7 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template<typename T> requires std::integral<T> static T roundToNearestMultiple(T num, T mult)
+ *  @fn T roundToNearestMultiple(T num, T mult)
  *
  *  Returns the multiple of @a mult that @a num is closest to.
  *
@@ -170,21 +170,21 @@ unsigned long long abs(unsigned long long n) { return n; }
  */
 
 /*!
- *  @fn template <typename T> requires std::integral<T> static T ceilPowOfTwo(T num)
+ *  @fn T ceilPowOfTwo(T num)
  *
  *  Returns the next (i.e. higher) power of two after @a num, or @a num if it is
  *  already a power of two.
  */
 
 /*!
- *  @fn template <typename T> requires std::integral<T> static T floorPowOfTwo(T num)
+ *  @fn T floorPowOfTwo(T num)
  *
  *  Returns the previous (i.e. lower) power of two before @a num, or @a num if it is
  *  already a power of two.
  */
 
 /*!
- *  @fn template <typename T> requires std::integral<T> static T roundPowOfTwo(T num)
+ *  @fn T roundPowOfTwo(T num)
  *
  *  Returns the power of two that is closest to @a num.
  */

--- a/lib/core/src/qx-array.dox
+++ b/lib/core/src/qx-array.dox
@@ -14,32 +14,32 @@ namespace Qx
 //-Class Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template <typename T, int N> static constexpr int Array::constDim(T(&)[N])
+ *  @fn int Array::constDim(T(&)[N])
  *
  *  Returns the size of the given statically-sized array; therefore, this only works for arrays who's size are
  *  determined at compile time.
  */
 
 /*!
- *  @fn template <typename T, int N> static int Array::indexOf(T(&array) [N], T query)
+ *  @fn int Array::indexOf(T(&array) [N], T query)
  *
  *  Finds and returns the position of @a query within @a array, or -1 if it could not be found.
  */
 
 /*!
- *  @fn template<typename T, int N> requires arithmetic<T> static T Array::maxOf(T(&array) [N])
+ *  @fn T Array::maxOf(T(&array) [N])
  *
  *  Returns the highest value in @a array.
  */
 
 /*!
- *  @fn template<typename T, int N> requires arithmetic<T> static T Array::minOf(T(&array) [N])
+ *  @fn T Array::minOf(T(&array) [N])
  *
  *  Returns the lowest value in @a array.
  */
 
 /*!
- *  @fn template<typename T, int N> Array::mostFrequent(T(&array) [N])
+ *  @fn T Array::mostFrequent(T(&array) [N])
  *
  *  Returns the most frequently occurring value of @a array.
  */

--- a/lib/core/src/qx-bitarray.cpp
+++ b/lib/core/src/qx-bitarray.cpp
@@ -26,7 +26,7 @@ namespace Qx
 //-Class Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template<typename T> requires std::integral<T> static BitArray BitArray::fromInteger(const T& integer)
+ *  @fn BitArray BitArray::fromInteger(const T& integer)
  *
  *  Converts the primitive @a integer to a bit array, with the resultant contents encoded in big-endian
  *  format if a multibyte integer type is provided.
@@ -50,7 +50,7 @@ BitArray::BitArray(int size, bool value) : QBitArray(size, value) {}
 //-Instance Functions--------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template<typename T> requires std::integral<T> T BitArray::toInteger()
+ *  @fn T BitArray::toInteger()
  *
  *  Converts the contents of the bit array to an integer, with the contents interpreted as being in big-endian
  *  format if a multibyte integer type is specified.
@@ -120,7 +120,7 @@ void BitArray::replace(const BitArray& bits, int start, int length)
 }
 
 /*!
- *  @fn template<typename T> requires std::integral<T> void BitArray::replace(T integer, int start = 0, int length = -1)
+ *  @fn void BitArray::replace(T integer, int start = 0, int length = -1)
  *
  *  Replace at most @a length bits at index @a start with the bits that make up @a integer.
  *

--- a/lib/core/src/qx-bytearray.dox
+++ b/lib/core/src/qx-bytearray.dox
@@ -14,7 +14,7 @@ namespace Qx
 //-Class Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template<typename T> requires arithmetic<T> static QByteArray ByteArray::fromPrimitive(T primitive, QSysInfo::Endian endianness = QSysInfo::ByteOrder)
+ *  @fn QByteArray ByteArray::fromPrimitive(T primitive, QSysInfo::Endian endianness = QSysInfo::ByteOrder)
  *
  *  Creates a byte array from the integer value @a primitive, using @a endianness byte-ordering if @a T requires
  *  multiple bytes to store, and returns it.
@@ -24,7 +24,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<> inline QByteArray ByteArray::fromPrimitive<bool>(bool primitive, QSysInfo::Endian endianness)
+ *  @fn QByteArray ByteArray::fromPrimitive<bool>(bool primitive, QSysInfo::Endian endianness)
  *  @overload
  *
  *  Template specialization of the above for <tt>T == bool</tt>.
@@ -35,7 +35,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> requires arithmetic<T> static T ByteArray::toPrimitive(QByteArray ba, QSysInfo::Endian endianness = QSysInfo::ByteOrder)
+ *  @fn T ByteArray::toPrimitive(QByteArray ba, QSysInfo::Endian endianness = QSysInfo::ByteOrder)
  *
  *  Returns the raw binary data in @a ba reinterpreted as fundamental type @a T, according to the byte-order
  *  specified by @a endianness for multi-byte values.

--- a/lib/core/src/qx-cumulation.dox
+++ b/lib/core/src/qx-cumulation.dox
@@ -26,7 +26,7 @@ namespace Qx
 //-Constructor----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template <typename K, typename V> Cumulation<K, V>::Cumulation()
+ * @fn Cumulation<K, V>::Cumulation()
  *
  *  Creates an empty cumulation with a total of zero.
  */
@@ -34,7 +34,7 @@ namespace Qx
 //-Class Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::insert(K component, V value, V scaler = 1)
+ *  @fn void Cumulation<K, V>::insert(K component, V value, V scaler = 1)
  *
  *  Inserts a new component with key @a component, value @a value, and scaler @a scaler.
  *
@@ -43,7 +43,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::setValue(K component, V value)
+ *  @fn void Cumulation<K, V>::setValue(K component, V value)
  *
  *  Sets the value of @a component to @a value.
  *
@@ -52,7 +52,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::setScaler(K component, V scaler)
+ *  @fn void Cumulation<K, V>::setScaler(K component, V scaler)
  *
  *  Sets the scaler of @a component to @a scaler.
  *
@@ -64,7 +64,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::increase(K component, V amount)
+ *  @fn void Cumulation<K, V>::increase(K component, V amount)
  *
  *  Adds @a amount to the value of @a component.
  *
@@ -73,7 +73,7 @@ namespace Qx
  */
 
 /*!
-*  @fn template <typename K, typename V> void Cumulation<K, V>::reduce(K component, V amount)
+*  @fn void Cumulation<K, V>::reduce(K component, V amount)
 *
 *  Subtracts @a amount from the value of @a component.
 *
@@ -82,7 +82,7 @@ namespace Qx
 */
 
 /*!
- *  @fn template <typename K, typename V> V Cumulation<K, V>::increment(K component)
+ *  @fn V Cumulation<K, V>::increment(K component)
  *
  *  Increments the value of the given @a component and returns the new total.
  *
@@ -91,7 +91,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template <typename K, typename V> V Cumulation<K, V>::decrement(K component)
+ *  @fn V Cumulation<K, V>::decrement(K component)
  *
  *  Decrements the value of the given @a component and returns the new total.
  *
@@ -100,38 +100,38 @@ namespace Qx
  */
 
 /*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::remove(K component)
+ *  @fn void Cumulation<K, V>::remove(K component)
  *
  *  Removes the value associated with the key @a component from the cumulation, if it exists.
  */
 
 /*!
- *  @fn template <typename K, typename V> void Cumulation<K, V>::clear()
+ *  @fn void Cumulation<K, V>::clear()
  *
  *  Removes all keys/values from the cumulation, resulting in a total of zero.
  */
 
 /*!
- *  @fn template <typename K, typename V> bool Cumulation<K, V>::contains(K component) const
+ *  @fn bool Cumulation<K, V>::contains(K component) const
  *
  *  Returns @c true if the cumulation contains a value associated with the key @a component; otherwise returns
  *  @c false.
  */
 
 /*!
- *  @fn template <typename K, typename V> V Cumulation<K, V>::value(K component) const
+ *  @fn V Cumulation<K, V>::value(K component) const
  *
  *  Returns the value of @a component, or a default-constructed value if not present.
  */
 
 /*!
- *  @fn template <typename K, typename V> V Cumulation<K, V>::total() const
+ *  @fn V Cumulation<K, V>::total() const
  *
  *  Returns the current total of the cumulation, which is the sum of all its component values.
  */
 
 /*!
- * @fn template <typename K, typename V> QList<K> Cumulation<K, V>::components() const
+ * @fn QList<K> Cumulation<K, V>::components() const
  *
  *  Returns a list containing all the components in the cumulation, in an arbitrary order.
  *
@@ -139,19 +139,19 @@ namespace Qx
  */
 
 /*!
- * @fn template <typename K, typename V> qsizetype Cumulation<K, V>::count() const
+ * @fn qsizetype Cumulation<K, V>::count() const
  *
  *  Returns that number of components that compose the cumulation.
  */
 
 /*!
- * @fn template <typename K, typename V> bool Cumulation<K, V>::isEmpty() const
+ * @fn bool Cumulation<K, V>::isEmpty() const
  *
  *  Returns @c true if the cumulation has no components; otherwise, returns @c false.
  */
 
 /*!
- *  @fn template <typename K, typename V> V Cumulation<K, V>::mean() const
+ *  @fn V Cumulation<K, V>::mean() const
  *
  *  Returns the current mean of the cumulation, which is the sum of all its component values divided the
  *  number of components, or zero if the cumulation is empty.
@@ -160,14 +160,14 @@ namespace Qx
  */
 
 /*!
- *  @fn template <typename K, typename V> V Cumulation<K, V>::operator==(const Cumulation& other) const
+ *  @fn V Cumulation<K, V>::operator==(const Cumulation& other) const
  *
  *  Returns @c true if this Cumulation and @a other Cumulation are the same;
  *  otherwise, returns @c false.
  */
 
 /*!
- *  @fn template <typename K, typename V> V Cumulation<K, V>::operator!=(const Cumulation& other) const
+ *  @fn V Cumulation<K, V>::operator!=(const Cumulation& other) const
  *
  *  Returns @c true if this Cumulation and @a other Cumulation are not the same;
  *  otherwise, returns @c false.

--- a/lib/core/src/qx-freeindextracker.dox
+++ b/lib/core/src/qx-freeindextracker.dox
@@ -18,7 +18,7 @@ namespace Qx
 //-Constructor----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template <typename T> FreeIndexTracker<T>::FreeIndexTracker(T minIndex = 0, T maxIndex = 0, QSet<T> reservedIndices = QSet<T>())
+ * @fn FreeIndexTracker<T>::FreeIndexTracker(T minIndex = 0, T maxIndex = 0, QSet<T> reservedIndices = QSet<T>())
  *
  *  Creates an index tracker for the range @a minIndex to @a maxIndex, with the indices from @a reservedIndices
  *  already reserved.
@@ -35,70 +35,70 @@ namespace Qx
 //-Class Functions--------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template <typename T> bool FreeIndexTracker<T>::isReserved(T index) const
+ *  @fn bool FreeIndexTracker<T>::isReserved(T index) const
  *
  *  Returns @c true if @a index is occupied; otherwise returns @c false.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::minimum() const
+ *  @fn T FreeIndexTracker<T>::minimum() const
  *
  *  Returns the lower bound of the index tracker.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::maximum() const
+ *  @fn T FreeIndexTracker<T>::maximum() const
  *
  *  Returns the upper bound of the index tracker.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::firstReserved() const
+ *  @fn T FreeIndexTracker<T>::firstReserved() const
  *
  *  Returns the lowest index that is currently reserved, or -1 if all are free.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::lastReserved() const
+ *  @fn T FreeIndexTracker<T>::lastReserved() const
  *
  *  Returns the highest index that is currently reserved, or -1 if all are free.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::firstFree() const
+ *  @fn T FreeIndexTracker<T>::firstFree() const
  *
  *  Returns the lowest available index, or -1 if all are reserved.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::lastFree() const
+ *  @fn T FreeIndexTracker<T>::lastFree() const
  *
  *  Returns the highest available index, or -1 if all are reserved.
  */
 
 /*!
- *  @fn template <typename T> bool FreeIndexTracker<T>::reserve(int index)
+ *  @fn bool FreeIndexTracker<T>::reserve(int index)
  *
  *  Attempts to mark @a index as occupied and returns @c true if successful, or @c false if the index was
  *  already reserved.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::reserveFirstFree()
+ *  @fn T FreeIndexTracker<T>::reserveFirstFree()
  *
  *  Attempts to mark the lowest available index as occupied and return it if successful, or -1 if there
  *  are no free indices.
  */
 
 /*!
- *  @fn template <typename T> T FreeIndexTracker<T>::reserveLastFree()
+ *  @fn T FreeIndexTracker<T>::reserveLastFree()
  *
  *  Attempts to mark the highest available index as occupied and return it if successful, or -1 if there
  *  are no free indices.
  */
 
 /*!
- *  @fn template <typename T> bool FreeIndexTracker<T>::release(int index)
+ *  @fn bool FreeIndexTracker<T>::release(int index)
  *
  *  Attempts to mark @a index as unoccupied and returns @c true if successful, or @c false if the index was
  *  already free.

--- a/lib/core/src/qx-index.dox
+++ b/lib/core/src/qx-index.dox
@@ -55,7 +55,7 @@ namespace Qx
 //-Class Members----------------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @var template<typename T> Index<T> Index<T>::FIRST
+ *  @var Index<T> Index<T>::FIRST
  *
  *  Used to refer to the first index of a dataset.
  *
@@ -63,7 +63,7 @@ namespace Qx
  */
 
 /*!
- *  @var template<typename T> Index<T> Index<T>::LAST
+ *  @var Index<T> Index<T>::LAST
  *
  *  Used to refer to the last index of a dataset.
  */
@@ -71,13 +71,13 @@ namespace Qx
 //-Constructor----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template<typename T> Index<T>::Index()
+ * @fn Index<T>::Index()
  *
  *  Creates an null index.
  */
 
 /*!
- * @fn template<typename T> Index<T>::Index(T value)
+ * @fn Index<T>::Index(T value)
  *
  *  Creates an index with the underlying @a value.
  *
@@ -87,13 +87,13 @@ namespace Qx
 //-Instance Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template<typename T> bool Index<T>::isNull() const
+ * @fn bool Index<T>::isNull() const
  *
  *  Returns @c true if the index is null; otherwise returns @c false.
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::isLast() const
+ * @fn bool Index<T>::isLast() const
  *
  *  Returns @c true if the index represents the last index of an arbitrary dataset; otherwise returns @c false.
  *
@@ -101,7 +101,7 @@ namespace Qx
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::isLast() const
+ * @fn bool Index<T>::isLast() const
  *
  *  Returns @c true if the index represents the last index of an arbitrary dataset; otherwise returns @c false.
  *
@@ -109,20 +109,20 @@ namespace Qx
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::operator==(const Index<T>& other)
+ * @fn bool Index<T>::operator==(const Index<T>& other)
  *
  *  Returns @c true if this index and @a other are both null, 'last', or have the same underlying value; otherwise
  *  returns @c false.
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::operator!=(const Index<T>& other)
+ * @fn bool Index<T>::operator!=(const Index<T>& other)
  *
  *  Returns @c true if this index and @a other are not equivalent; otherwise returns @c false.
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::operator<(const Index<T>& other)
+ * @fn bool Index<T>::operator<(const Index<T>& other)
  *
  *  Returns @c true if one of the following is true:
  *
@@ -134,13 +134,13 @@ namespace Qx
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::operator<=(const Index<T>& other)
+ * @fn bool Index<T>::operator<=(const Index<T>& other)
  *
  *  See operator<(const Index<T>& other) and operator==(const Index<T>& other)
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::operator>(const Index<T>& other)
+ * @fn bool Index<T>::operator>(const Index<T>& other)
  *
  *  Returns @c true if one of the following is true:
  *
@@ -152,85 +152,85 @@ namespace Qx
  */
 
 /*!
- * @fn template<typename T> bool Index<T>::operator>=(const Index<T>& other)
+ * @fn bool Index<T>::operator>=(const Index<T>& other)
  *
  *  See operator>(const Index<T>& other) and operator==(const Index<T>& other)
  */
 
 /*!
- * @fn template<typename T> Index<T> Index<T>::operator-(const Index<T>& other)
+ * @fn Index<T> Index<T>::operator-(const Index<T>& other)
  *
  *  Returns an index that is the difference between this index and @a other.
  */
 
 /*!
- * @fn template<typename T> Index<T>& Index<T>::operator-=(const Index<T>& other)
+ * @fn Index<T>& Index<T>::operator-=(const Index<T>& other)
  *
  *  Subtracts @a other from this index and returns a reference to this index.
  */
 
 /*!
- * @fn template<typename T> Index<T> Index<T>::operator+(const Index<T>& other)
+ * @fn Index<T> Index<T>::operator+(const Index<T>& other)
  *
  *  Returns an index that is the sum between this index and @a other.
  */
 
 /*!
- * @fn template<typename T> Index<T>& Index<T>::operator+=(const Index<T>& other)
+ * @fn Index<T>& Index<T>::operator+=(const Index<T>& other)
  *
  *  Adds @a other from this index and returns a reference to this index.
  */
 
 /*!
- * @fn template<typename T> Index<T> Index<T>::operator/(const Index<T>& other)
+ * @fn Index<T> Index<T>::operator/(const Index<T>& other)
  *
  *  Returns an index that is the quotient of this index and @a other.
  */
 
 /*!
- * @fn template<typename T> Index<T>& Index<T>::operator/=(const Index<T>& other)
+ * @fn Index<T>& Index<T>::operator/=(const Index<T>& other)
  *
  *  Divides @a other from this index and returns a reference to this index.
  */
 
 /*!
- * @fn template<typename T> Index<T> Index<T>::operator*(const Index<T>& other)
+ * @fn Index<T> Index<T>::operator*(const Index<T>& other)
  *
  *  Returns an index that is the product of this index and @a other.
  */
 
 /*!
- * @fn template<typename T> Index<T>& Index<T>::operator*=(const Index<T>& other)
+ * @fn Index<T>& Index<T>::operator*=(const Index<T>& other)
  *
  *  Multiplies @a other with this index and returns a reference to this index.
  */
 
 /*!
- * @fn template<typename T> Index<T>& Index<T>::operator++()
+ * @fn Index<T>& Index<T>::operator++()
  *
  *  Increases the index by 1, unless its 'last' or null, and returns a reference to the index.
  */
 
 /*!
- * @fn template<typename T> Index<T> Index<T>::operator++(int)
+ * @fn Index<T> Index<T>::operator++(int)
  *
  *  Increases the index by 1, unless its 'last' or null, and returns a pre-increment copy of the index.
  */
 
 /*!
- * @fn template<typename T> Index<T>& Index<T>::operator--()
+ * @fn Index<T>& Index<T>::operator--()
  *
  *  Decreases the index by 1, unless its 'last' or null, and returns a reference to the index.
  */
 
 /*!
- * @fn template<typename T> Index<T> Index<T>::operator--(int)
+ * @fn Index<T> Index<T>::operator--(int)
  *
  *  Decreases the index by 1, unless its 'last' or null, and returns a pre-decrement copy of the index.
  */
 
 /*!
- * @fn template<typename T> T Index<T>::operator*()
+ * @fn T Index<T>::operator*()
  *
  *  Returns the underlying value of the index.
  *
@@ -241,7 +241,7 @@ namespace Qx
  */
 
 /*!
- * @fn template<typename T> T Index<T>::operator*()
+ * @fn T Index<T>::operator*()
  *
  *  Returns the underlying value of the index.
  *

--- a/lib/core/src/qx-json.cpp
+++ b/lib/core/src/qx-json.cpp
@@ -45,7 +45,7 @@ namespace Qx
 //Public:
 
 /*!
- *  @fn static GenericError Json::checkedKeyRetrieval(T& valueBuffer, QJsonObject jObject, const QString& key)
+ *  @fn GenericError Json::checkedKeyRetrieval(T& valueBuffer, QJsonObject jObject, const QString& key)
  *
  *  Safely retrieves the value associated with the specified key from the given JSON Object.
  *
@@ -64,7 +64,7 @@ namespace Qx
  */
 
 /*!
- *  @fn static GenericError Json::checkedArrayConversion(QList<T>& valueBuffer, QJsonArray jArray)
+ *  @fn GenericError Json::checkedArrayConversion(QList<T>& valueBuffer, QJsonArray jArray)
  *
  *  Safely transforms the provided JSON array into a list of values of its underlying type.
  *
@@ -80,7 +80,7 @@ namespace Qx
  */
 
 /*!
- * @fn static GenericError Json::checkedArrayConversion(QSet<T>& valueBuffer, QJsonArray jArray)
+ * @fn GenericError Json::checkedArrayConversion(QSet<T>& valueBuffer, QJsonArray jArray)
  *
  * @overload
  *

--- a/lib/core/src/qx-list.dox
+++ b/lib/core/src/qx-list.dox
@@ -14,20 +14,20 @@ namespace Qx
 //-Class Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template<typename T> static QList<T>* List::subListThatContains(T element, QList<QList<T>*> listOfLists)
+ *  @fn QList<T>* List::subListThatContains(T element, QList<QList<T>*> listOfLists)
  *
  *  Returns a pointer to the first list found within @a listOfLists that contains @a element, or @c nullptr if
  *  none were found.
  */
 
 /*!
- *  @fn template<typename T> static QList<T> List::difference(QList<T>& listA, QList<T>& listB)
+ *  @fn QList<T> List::difference(QList<T>& listA, QList<T>& listB)
  *
  *  Returns a new list that contains the elements of @a listA that are not present in @a listB.
  */
 
 /*!
- *  @fn template<typename T, typename F> requires static_castable_to<F*, T*> QList<T*> List::static_pointer_cast(const QList<F*> fromList)
+ *  @fn QList<T*> List::static_pointer_cast(const QList<F*> fromList)
  *
  *  Returns a new list with each pointer in @a fromList converted to T* using @c static_cast<T*>(F*).
  */

--- a/lib/core/src/qx-setonce.dox
+++ b/lib/core/src/qx-setonce.dox
@@ -14,7 +14,7 @@ namespace Qx
 //-Constructor----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template<typename T> SetOnce<T>::SetOnce(T initial)
+ * @fn SetOnce<T>::SetOnce(T initial)
  *
  *  Creates a SetOnce container that holds the initial value @a initial.
  *
@@ -25,19 +25,19 @@ namespace Qx
 //-Instance Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template<typename T> bool SetOnce<T>::isSet() const
+ * @fn SetOnce<T>::isSet() const
  *
  *  Returns @c true if the containers value has been set; otherwise returns @c false.
  */
 
 /*!
- * @fn template<typename T> const T& SetOnce<T>::value() const
+ * @fn const T& SetOnce<T>::value() const
  *
  *  Returns the current value of the container.
  */
 
 /*!
- * @fn template<typename T> void SetOnce<T>::reset()
+ * @fn void SetOnce<T>::reset()
  *
  *  Resets the container to its initial state.
  *
@@ -47,7 +47,7 @@ namespace Qx
  */
 
 /*!
- * @fn template<typename T> SetOnce<T>& SetOnce<T>::operator=(const T& value)
+ * @fn SetOnce<T>& SetOnce<T>::operator=(const T& value)
  *
  *  Sets the value of the container to @a value, if it is different from its initial value.
  *

--- a/lib/core/src/qx-string.cpp
+++ b/lib/core/src/qx-string.cpp
@@ -50,7 +50,7 @@ bool String::isValidChecksum(QString checksum, QCryptographicHash::Algorithm has
 QString String::stripToHexOnly(QString string) { return string.replace(RegularExpression::ANY_NON_HEX, ""); }
 
 /*!
- *  @fn template<typename T, typename F> static QString String::join(QList<T> list, F&& toStringFunc, QString separator = "", QString prefix = "")
+ *  @fn QString String::join(QList<T> list, F&& toStringFunc, QString separator = "", QString prefix = "")
  *
  *  Joins all arbitrarily typed elements from a list into a single string with optional formatting.
  *
@@ -73,7 +73,7 @@ QString String::join(QList<QString> list, QString separator, QString prefix) // 
 }
 
 /*!
- *  @fn template<typename T, typename F> static QString String::join(QSet<T> set, F&& toStringFunc, QString separator = "", QString prefix = "")
+ *  @fn QString String::join(QSet<T> set, F&& toStringFunc, QString separator = "", QString prefix = "")
  *  @overload
  *
  *  Joins all arbitrarily typed elements from a set into a single string with optional formatting.

--- a/lib/core/src/qx-table.dox
+++ b/lib/core/src/qx-table.dox
@@ -34,26 +34,26 @@ namespace Qx
 //-Constructor----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template<typename T> Table<T>::Table()
+ * @fn Table<T>::Table()
  *
  *  Constructs an empty Table.
  */
 
 /*!
- *  @fn template<typename T> Table<T>::Table(QSize size)
+ *  @fn Table<T>::Table(QSize size)
  *
  *  Constructs a Table of size @a size, with every element initialized with a
  *  default-constructed value.
  */
 
 /*!
- *  @fn template<typename T> Table<T>::Table(QSize size, const T& value)
+ *  @fn Table<T>::Table(QSize size, const T& value)
  *
  *  Constructs a Table of size @a size, with every element initialized to @a value.
  */
 
 /*!
- *  @fn template<typename T> Table<T>::Table(std::initializer_list<std::initializer_list<T>> table)
+ *  @fn Table<T>::Table(std::initializer_list<std::initializer_list<T>> table)
  *
  *  Constructs a Table with a copy of each row in the initializer list @a list.
  *
@@ -64,7 +64,7 @@ namespace Qx
 //-Instance Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template<typename T> T& Table<T>::at(qsizetype r, qsizetype c)
+ *  @fn T& Table<T>::at(qsizetype r, qsizetype c)
  *
  *  Returns the element at row @a r and column @a c as a modifiable reference.
  *
@@ -75,7 +75,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> const T& Table<T>::at(qsizetype r, qsizetype c) const
+ *  @fn const T& Table<T>::at(qsizetype r, qsizetype c) const
  *
  *  @overload
  *
@@ -83,7 +83,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QSize Table<T>::capacity() const
+ *  @fn QSize Table<T>::capacity() const
  *
  *  Returns the capacity of the table as a QSize object.
  *
@@ -91,7 +91,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QList<T> Table<T>::columnAt(qsizetype i) const
+ *  @fn QList<T> Table<T>::columnAt(qsizetype i) const
  *
  *  Returns the items in column @a i of the table as a list.
  *
@@ -101,7 +101,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> qsizetype Table<T>::columnCount() const
+ *  @fn qsizetype Table<T>::columnCount() const
  *
  *  Returns the number of columns in the table.
  *
@@ -109,7 +109,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QList<T> Table<T>::firstColumn() const
+ *  @fn QList<T> Table<T>::firstColumn() const
  *
  *  Returns the items in the first column of the table as a list.
  *  This function assumes that the table isn't empty.
@@ -118,7 +118,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QList<T> Table<T>::firstRow() const
+ *  @fn QList<T> Table<T>::firstRow() const
  *
  *  Returns the items in the first row of the table as a list.
  *  This function assumes that the table isn't empty.
@@ -127,13 +127,13 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> qsizetype Table<T>::height() const
+ *  @fn qsizetype Table<T>::height() const
  *
  *  Same as rowCount().
  */
 
 /*!
- *  @fn template<typename T> bool Table<T>::isEmpty() const
+ *  @fn bool Table<T>::isEmpty() const
  *
  *  Returns @c true if the table has no elements; otherwise, returns @c false.
  *
@@ -141,7 +141,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QList<T> Table<T>::lastColumn() const
+ *  @fn QList<T> Table<T>::lastColumn() const
  *
  *  Returns the items in the last column of the table as a list.
  *  This function assumes that the table isn't empty.
@@ -150,7 +150,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QList<T> Table<T>::lastRow() const
+ *  @fn QList<T> Table<T>::lastRow() const
  *
  *  Returns the items in the last row of the table as a list.
  *  This function assumes that the table isn't empty.
@@ -159,7 +159,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QList<T> Table<T>::rowAt(qsizetype i) const
+ *  @fn QList<T> Table<T>::rowAt(qsizetype i) const
  *
  *  Returns the items in row @a i of the table as a list.
  *
@@ -169,7 +169,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> row_iterator Table<T>::rowBegin() const
+ *  @fn row_iterator Table<T>::rowBegin() const
  *
  *  Returns a const STL-style iterator pointing to the first row in the table.
  *
@@ -179,7 +179,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> qsizetype Table<T>::rowCount() const
+ *  @fn qsizetype Table<T>::rowCount() const
  *
  *  Returns the number of rows in the table.
  *
@@ -187,7 +187,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> row_iterator Table<T>::rowEnd() const
+ *  @fn row_iterator Table<T>::rowEnd() const
  *
  *  Returns a const STL-style iterator pointing just after the last row in the table.
  *
@@ -197,7 +197,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> Table<T> Table<T>::section(qsizetype r, qsizetype c, qsizetype height, qsizetype width) const
+ *  @fn Table<T> Table<T>::section(qsizetype r, qsizetype c, qsizetype height, qsizetype width) const
  *
  *  Returns a new Table that contains a portion of the table's elements.
  *
@@ -214,7 +214,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> QSize Table<T>::size() const
+ *  @fn QSize Table<T>::size() const
  *
  *  Returns the column count (width), and row count (height) of the table as a QSize object.
  *
@@ -222,7 +222,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> T Table<T>::value(qsizetype r, qsizetype c) const
+ *  @fn T Table<T>::value(qsizetype r, qsizetype c) const
  *
  *  Returns the element at row @a r and column @a c.
  *
@@ -232,7 +232,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> T Table<T>::value(qsizetype r, qsizetype c, const T& defaultValue) const
+ *  @fn T Table<T>::value(qsizetype r, qsizetype c, const T& defaultValue) const
  *
  *  @overload
  *
@@ -240,7 +240,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::addColumns(qsizetype c)
+ *  @fn void Table<T>::addColumns(qsizetype c)
  *
  *  Appends @a c columns, with their elements initialized to default-constructed values, to the
  *  'right' end of the table.
@@ -254,7 +254,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::addRows(qsizetype c)
+ *  @fn void Table<T>::addRows(qsizetype c)
  *
  *  Appends @a c columns, with their elements initialized to default-constructed values, to the
  *  'bottom' end of the table.
@@ -268,7 +268,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::appendColumn(const QList<T>& c)
+ *  @fn void Table<T>::appendColumn(const QList<T>& c)
  *
  *  Appends @a c as a column to the 'right' end of the table.
  *
@@ -279,7 +279,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::appendRow(const QList<T>& r)
+ *  @fn void Table<T>::appendRow(const QList<T>& r)
  *
  *  Appends @a r as a row to the 'bottom' end of the table.
  *
@@ -290,7 +290,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::fill(const T& value, QSize size)
+ *  @fn void Table<T>::fill(const T& value, QSize size)
  *
  *  Assigns @a value to all items in the table. If @a size is not null (the default), the table is
  *  resized to @a size beforehand.
@@ -299,7 +299,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::insertColumn(qsizetype i, const QList<T>& c)
+ *  @fn void Table<T>::insertColumn(qsizetype i, const QList<T>& c)
  *
  *  Inserts @a c as a column to column index @a i in the table. If @a i is 0, the column is prepended to the
  *  table. If @a i is columnSize(), the column is appended to the table.
@@ -311,7 +311,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::insertRow(qsizetype i, const QList<T>& r)
+ *  @fn void Table<T>::insertRow(qsizetype i, const QList<T>& r)
  *
  *  Inserts @a r as a row to row index @a i in the table. If @a i is 0, the row is prepended to the
  *  table. If @a i is rowSize(), the row is appended to the table.
@@ -323,7 +323,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeColumnAt(qsizetype i)
+ *  @fn void Table<T>::removeColumnAt(qsizetype i)
  *
  *  Removes the column @a i from the table.
  *
@@ -334,7 +334,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeColumns(qsizetype i, qsizetype n = 1)
+ *  @fn void Table<T>::removeColumns(qsizetype i, qsizetype n = 1)
  *
  *  Removes @a n columns from the table, starting at column @a i.
  *
@@ -345,7 +345,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeRowAt(qsizetype i)
+ *  @fn void Table<T>::removeRowAt(qsizetype i)
  *
  *  Removes the row @a i from the table.
  *
@@ -356,7 +356,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeRows(qsizetype i, qsizetype n = 1)
+ *  @fn void Table<T>::removeRows(qsizetype i, qsizetype n = 1)
  *
  *  Removes @a n rows from the table, starting at row @a i.
  *
@@ -367,7 +367,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeFirstColumn()
+ *  @fn void Table<T>::removeFirstColumn()
  *
  *  Removes the first column from the table. Calling this function is equivalent to calling `removeColumns(0)`.
  *  The table must have columns. To prevent failure, call columnCount() before calling this function.
@@ -379,7 +379,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeFirstRow()
+ *  @fn void Table<T>::removeFirstRow()
  *
  *  Removes the first row from the table. Calling this function is equivalent to calling `removeRows(0)`.
  *  The table must have rows. To prevent failure, call rowCount() before calling this function.
@@ -391,7 +391,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeLastColumn()
+ *  @fn void Table<T>::removeLastColumn()
  *
  *  Removes the last column from the table. Calling this function is equivalent to calling
  *  `removeColumns(columnCount() - 1)`. The table must have columns. To prevent failure, call
@@ -404,7 +404,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::removeLastRow()
+ *  @fn void Table<T>::removeLastRow()
  *
  *  Removes the last row from the table. Calling this function is equivalent to calling
  *  `removeRows(rowCount() - 1)`. The table must have rows. To prevent failure, call
@@ -417,7 +417,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::replaceColumn(qsizetype i, const QList<T>& c)
+ *  @fn void Table<T>::replaceColumn(qsizetype i, const QList<T>& c)
  *
  *  Replaces column @a i with @a c in the table.
  *
@@ -428,7 +428,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::replaceRow(qsizetype i, const QList<T>& r)
+ *  @fn void Table<T>::replaceRow(qsizetype i, const QList<T>& r)
  *
  *  Replaces row @a i with @a r in the table.
  *
@@ -439,7 +439,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::reserve(QSize size)
+ *  @fn void Table<T>::reserve(QSize size)
  *
  *  Attempts to allocate memory for @a size elements.
  *
@@ -468,7 +468,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::resize(QSize size)
+ *  @fn void Table<T>::resize(QSize size)
  *
  *  Sets the size of the table to @a size. If @a size is greater than the current size, elements
  *  are added to each end of the table; the new elements are initialized with default-constructed values.
@@ -478,7 +478,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::resizeColumns(qsizetype size)
+ *  @fn void Table<T>::resizeColumns(qsizetype size)
  *
  *  Sets the number of columns in the table to @a size. If @a size is greater than the current
  *  column count, columns are added to the 'right' end of the table; the new elements are
@@ -489,7 +489,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::resizeRows(qsizetype size)
+ *  @fn void Table<T>::resizeRows(qsizetype size)
  *
  *  Sets the number of rows in the table to @a size. If @a size is greater than the current
  *  row count, rows are added to the 'bottom' end of the table; the new elements are
@@ -500,7 +500,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::squeeze()
+ *  @fn void Table<T>::squeeze()
  *
  *  Releases any memory not required to store the elements.
  *
@@ -511,7 +511,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::takeColumnAt(qsizetype i)
+ *  @fn void Table<T>::takeColumnAt(qsizetype i)
  *
  *  Removes column @a i and returns it.
  *
@@ -526,7 +526,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::takeFirstColumn()
+ *  @fn void Table<T>::takeFirstColumn()
  *
  *  Removes the first column from the table and returns it. This function assumes the table
  *  has columns. To avoid failure, call columnCount() before calling this function.
@@ -535,7 +535,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::takeFirstRow()
+ *  @fn void Table<T>::takeFirstRow()
  *
  *  Removes the first row from the table and returns it. This function assumes the table
  *  has rows. To avoid failure, call rowCount() before calling this function.
@@ -544,7 +544,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::takeLastColumn()
+ *  @fn void Table<T>::takeLastColumn()
  *
  *  Removes the last column from the table and returns it. This function assumes the table
  *  has columns. To avoid failure, call columnCount() before calling this function.
@@ -553,7 +553,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::takeLastRow()
+ *  @fn void Table<T>::takeLastRow()
  *
  *  Removes the last row from the table and returns it. This function assumes the table
  *  has rows. To avoid failure, call rowCount() before calling this function.
@@ -562,7 +562,7 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> void Table<T>::takeRowAt(qsizetype i)
+ *  @fn void Table<T>::takeRowAt(qsizetype i)
  *
  *  Removes row @a i and returns it.
  *
@@ -577,19 +577,19 @@ namespace Qx
  */
 
 /*!
- *  @fn template<typename T> qsizetype Table<T>::width() const
+ *  @fn qsizetype Table<T>::width() const
  *
  *  Same as columnCount().
  */
 
 /*!
- *  @fn template<typename T> bool Table<T>::operator==(const Table& other) const
+ *  @fn bool Table<T>::operator==(const Table& other) const
  *
  *  Returns @c true if the table contains the same elements as @a other; otherwise, returns @c false.
  */
 
 /*!
- *  @fn template<typename T> bool Table<T>::operator!=(const Table& other) const
+ *  @fn bool Table<T>::operator!=(const Table& other) const
  *
  *  Returns @c true if the table does not contain the same elements as @a other; otherwise, returns @c false.
  */

--- a/lib/core/src/qx-traverser.dox
+++ b/lib/core/src/qx-traverser.dox
@@ -21,7 +21,7 @@ namespace Qx
 //-Constructor----------------------------------------------------------------------------------------------
 //Public:
 /*!
- * @fn template<typename T> Traverser<T>::Traverser(const T& traverseable)
+ * @fn Traverser<T>::Traverser(const T& traverseable)
  *
  *  Creates an traverser for iterating over @a traverseable, initialized to the beginning.
  */
@@ -29,44 +29,44 @@ namespace Qx
 //-Class Functions----------------------------------------------------------------------------------------------
 //Public:
 /*!
- *  @fn template<typename T> void Traverser<T>::advance(quint32 count = 1)
+ *  @fn void Traverser<T>::advance(quint32 count = 1)
  *
  *  Advances the traverser @a count elements, stopping at the end if it is reached.
  */
 
 /*!
- *  @fn template<typename T> void Traverser<T>::retreat(quint32 count = 1)
+ *  @fn void Traverser<T>::retreat(quint32 count = 1)
  *
  *  Reverses the traverser @a count elements, stopping at the beginning if it is reached.
  */
 
 /*!
- *  @fn template<typename T> bool Traverser<T>::atEnd() const
+ *  @fn bool Traverser<T>::atEnd() const
  *
  *  Reverses @c true if the traverser is at the end of the traversable; otherwise, returns @c false.
  */
 
 /*!
- *  @fn template<typename T> std::iter_value_t<typename T::const_iterator> Traverser<T>::currentValue() const
+ *  @fn std::iter_value_t<typename T::const_iterator> Traverser<T>::currentValue() const
  *
  *  Returns the value at the traverser's current position.
  */
 
 /*!
- *  @fn template<typename T> quint32 Traverser<T>::currentIndex() const
+ *  @fn quint32 Traverser<T>::currentIndex() const
  *
  *  Returns the traverser's current position as an index.
  */
 
 /*!
- *  @fn template<typename T> std::iter_value_t<typename T::const_iterator> Traverser<T>::lookAhead(quint32 count = 1) const
+ *  @fn std::iter_value_t<typename T::const_iterator> Traverser<T>::lookAhead(quint32 count = 1) const
  *
  *  Returns the value at the position @a count ahead of the traverser's current position if that position is
  *  valid; otherwise returns a default-constructed value.
  */
 
 /*!
- *  @fn template<typename T> std::iter_value_t<typename T::const_iterator> Traverser<T>::lookBehind(quint32 count = 1) const
+ *  @fn std::iter_value_t<typename T::const_iterator> Traverser<T>::lookBehind(quint32 count = 1) const
  *
  *  Returns the value at the position @a count behind of the traverser's current position if that position is
  *  valid; otherwise returns a default-constructed value.

--- a/lib/io/src/qx-filestreamreader.cpp
+++ b/lib/io/src/qx-filestreamreader.cpp
@@ -250,7 +250,7 @@ IoOpReport FileStreamReader::skipRawData(int len)
 IoOpReport FileStreamReader::status() const { return mStatus; }
 
 /*!
-*  @fn template<typename T> requires defines_right_shift_for<QDataStream, T&> FileStreamReader& FileStreamReader::operator>>(T& d)
+*  @fn FileStreamReader& FileStreamReader::operator>>(T& d)
 *
 *  Reads the data type @c T into @a d, and returns a reference to the stream.
 *

--- a/lib/io/src/qx-filestreamwriter.cpp
+++ b/lib/io/src/qx-filestreamwriter.cpp
@@ -230,7 +230,7 @@ IoOpReport FileStreamWriter::writeRawData(const QByteArray& data)
 }
 
 /*!
- *  @fn template<typename T> requires defines_left_shift_for<QDataStream, T> FileStreamWriter& FileStreamWriter::operator<<(T d)
+ *  @fn FileStreamWriter& FileStreamWriter::operator<<(T d)
  *
  *  Writes @a d of type @c T to the stream. Returns a reference to the stream.
  *

--- a/lib/io/src/qx-textstreamreader.cpp
+++ b/lib/io/src/qx-textstreamreader.cpp
@@ -364,7 +364,7 @@ void TextStreamReader::skipWhiteSpace()
 IoOpReport TextStreamReader::status() const { return mStatus; }
 
 /*!
- *  @fn template<typename T> requires defines_right_shift_for<QTextStream, T&> TextStreamReader& TextStreamReader::operator>>(T& d)
+ *  @fn TextStreamReader& TextStreamReader::operator>>(T& d)
  *
  *  Reads the data type @c T into @a d, and returns a reference to the stream.
  *

--- a/lib/io/src/qx-textstreamwriter.cpp
+++ b/lib/io/src/qx-textstreamwriter.cpp
@@ -335,7 +335,7 @@ void TextStreamWriter::setRealNumberPrecision(int precision) { mStreamWriter.set
 IoOpReport TextStreamWriter::status() const { return mStatus; }
 
 /*!
- *  @fn template<typename T> requires defines_left_shift_for<QTextStream, T> TextStreamWriter& TextStreamWriter::operator<<(T d)
+ *  @fn TextStreamWriter& TextStreamWriter::operator<<(T d)
  *
  *  Writes @a d of type @c T to the stream. Returns a reference to the stream.
  *

--- a/lib/utility/src/qx-helpers.dox
+++ b/lib/utility/src/qx-helpers.dox
@@ -8,7 +8,7 @@
 
 //Non-namespace Functions----------------------------------------------------------
 /*!
- *  @fn template <typename T> const T qxAsConst(T&& t)
+ *  @fn const T qxAsConst(T&& t)
  *
  *  Serves the same purpose as qAsConst() (preventing implicitly-shared Qt containers from
  *  detaching), but this version works for rvalues, albeit with some efficiency concerns
@@ -16,7 +16,7 @@
  */
 
 /*!
- *  @fn template <typename T> typename std::add_const<T>::type qxAsConst(T& t)
+ *  @fn std::add_const<T>::type qxAsConst(T& t)
  *  @overload
  *
  *  Equivalent to qAsConst(T& t).
@@ -28,7 +28,7 @@
 
 
 /*!
- *  @fn template <typename T> void qxDelete(T*& pointer)
+ *  @fn void qxDelete(T*& pointer)
  *
  *  Calls @c delete on @a pointer and then sets it to @c nullptr .
  */


### PR DESCRIPTION
Turns out that the full signature isn't required when using the @fn command.