### PR TITLE
Fix IoOpReport::toGenericError()

### DIFF
--- a/lib/io/src/qx-ioopreport.cpp
+++ b/lib/io/src/qx-ioopreport.cpp
@@ -399,10 +399,7 @@ bool IoOpReport::isNull() const { return mNull; }
  */
 GenericError IoOpReport::toGenericError() const
 {
-    if(isFailure())
-        return GenericError();
-    else
-        return GenericError(GenericError::Error, outcome(), outcomeInfo());
+    return isFailure() ? GenericError(GenericError::Error, outcome(), outcomeInfo()) : GenericError();
 }
 
 }


### PR DESCRIPTION
Logic for returning an invalid error was inverted.