### PR TITLE
Overhaul JSON facilities

### DIFF
--- a/cmake/module/Qx/ComponentHelper.cmake
+++ b/cmake/module/Qx/ComponentHelper.cmake
@@ -69,6 +69,7 @@ function(qx_add_component COMPONENT_NAME)
 
     # Function inputs
     set(oneValueArgs
+        TARGET_VAR
     )
 
     set(multiValueArgs
@@ -97,6 +98,9 @@ function(qx_add_component COMPONENT_NAME)
     else()
         set(COMPONENT_TYPE "INTERFACE")
     endif()
+    
+    # Determine target name
+    set(component_target "${PROJECT_NAMESPACE_LC}_${COMPONENT_NAME_LC}")
 
     # ---------- Generate Primary Include Header ------------
     # Get Date/Time
@@ -126,7 +130,7 @@ function(qx_add_component COMPONENT_NAME)
 
     # --------------------- Add Library -----------------------
     include(OB/Library)
-    ob_add_standard_library("${PROJECT_NAMESPACE_LC}_${COMPONENT_NAME_LC}"
+    ob_add_standard_library("${component_target}"
         NAMESPACE "${PROJECT_NAMESPACE}"
         ALIAS "${COMPONENT_NAME}"
         TYPE "${COMPONENT_TYPE}"
@@ -147,4 +151,9 @@ function(qx_add_component COMPONENT_NAME)
             ${COMPONENT_LINKS}
         CONFIG CUSTOM "${PROJECT_FILE_TEMPLATES}/${PROJECT_NAMESPACE}ComponentConfig.cmake.in"
     )
+    
+    # Return target name if requested
+    if(COMPONENT_TARGET_VAR)
+        set(${COMPONENT_TARGET_VAR} "${component_target}" PARENT_SCOPE)
+    endif()
 endfunction()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -13,6 +13,11 @@ set(DOXYGEN_HTML_COLORSTYLE_HUE 0)
 set(DOXYGEN_HTML_COLORSTYLE_SAT 255)
 set(DOXYGEN_HTML_COLORSTYLE_GAMMA 80)
 
+set(DOXYGEN_PREDEFINED
+    "QX_ERROR_TYPE(Type,Name,Code)=Type final : public Qx::AbstractError<Name, Code>"
+    "__QX_JSON_META_STRUCT="
+)
+
 # Setup documentation
 ob_standard_documentation(${DOC_TARGET_NAME}
     DOXY_VER 1.9.4

--- a/lib/core/doc/res/snippets/qx-json.cpp
+++ b/lib/core/doc/res/snippets/qx-json.cpp
@@ -1,0 +1,139 @@
+//! [0]
+{
+    "title": "Sample JSON Data",
+    "info": {
+        "rating": 10,
+        "cool": true
+    },
+    "reviews": [
+        "Wicked!",
+        "Awesome!",
+        "Fantastic!"
+    ]
+}
+//! [0]
+
+//! [1]
+#include <qx/core/qx-json.h>
+
+struct Info
+{
+    int rating;
+    bool cool;
+    
+    QX_JSON_STRUCT(rating, cool);
+}
+
+struct MyJson
+{
+    QString title;
+    Info info;
+    QList<QString> reviews;
+    
+    QX_JSON_STRUCT(title, info, reviews);
+};
+
+void main()
+{
+    // Get JSON data
+    QFile jsonFile("data.json");
+    Q_ASSERT(jsonFile.open(QIODevice::ReadOnly));
+
+    QByteArray jsonData = jsonFile.readAll();
+    jsonFile.close();
+
+    MyJson myJsonDoc;
+
+    // Parse raw JSON data
+    QJsonDocument jd = QJsonDocument::fromJson(jsonData);
+    Q_ASSERT(!jd.isEmpty());
+
+    // Parse into custom structures
+    Qx::JsonError je = Qx::parseJson(myJsonDoc, jd);
+    Q_ASSERT(!je.isValid());
+}
+//! [1]
+
+//! [2]
+struct MyStruct
+{
+    int number;
+    QString name;
+    
+    QX_JSON_STRUCT(number, name);
+}
+//! [2]
+
+//! [3]
+struct MySpecialStruct
+{
+    int number;
+    QString name;
+    
+    QX_JSON_STRUCT(number, name);
+    
+    QX_JSON_DECLARE_MEMBER_OVERRIDES();
+    
+    QX_JSON_MEMBER_OVERRIDE(name,
+        static Qx::JsonError fromJson(QString& member, const QJsonValue& jv)
+        {
+            member = "OverridenName";
+            return Qx::JsonError();
+        }
+    )
+}
+//! [3]
+
+//! [4]
+class MyType
+{
+    ...
+};
+
+namespace QxJson
+{
+    template<>
+    struct Converter<MyType>
+    {
+        static Qx::JsonError fromJson(MyType& value, const QJsonValue& jValue)
+        {
+            // Assign `value` to complete the conversion
+            value = //...
+            
+            // Return an invalid JsonError upon success, or a valid one if an error occurs
+            return Qx::JsonError();
+        }
+    };
+}
+//! [4]
+
+//! [5]
+struct MyStruct
+{
+    int number;
+    QString name;
+    
+    QX_JSON_STRUCT(number, name);
+};
+
+namespace QxJson
+{
+    template<>
+    QString keygen<QString, MyStruct>(const MyStruct& value)
+    {
+        // This specialization enables the use of QHash<QString, MyStruct>
+        // or QMap<QString, MyStruct> to represent a JSON array of JSON objects
+        // that are tied to MyStruct. The 'name' member is used as the key for each value.
+        return value.name;
+    };
+}
+
+// Use in another struct
+struct OtherStruct
+{
+    bool enabled;
+    QMap<QString, MyStruct> myStructs;
+    
+    QX_JSON_STRUCT(enabled, myStructs);
+};
+//! [5]

--- a/lib/core/include/qx/core/qx-abstracterror.h
+++ b/lib/core/include/qx/core/qx-abstracterror.h
@@ -39,7 +39,7 @@ private:
         u"Qx::SystemError",
         u"Qx::DownloadManagerReport",
         u"Qx::DownloadOpReport",
-        u"Qx::Json::Error"
+        u"Qx::JsonError"
     };
     // TODO: If this becomes sufficiently large, move to a constexpr set (hopefully available in std by that time)
 

--- a/lib/core/include/qx/core/qx-json.h
+++ b/lib/core/include/qx/core/qx-json.h
@@ -9,6 +9,7 @@
 #include <QJsonValueRef>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QJsonDocument>
 
 // Intra-component Includes
 #include "qx/core/qx-abstracterror.h"
@@ -17,164 +18,392 @@
 #include "qx/utility/qx-macros.h"
 #include "qx/utility/qx-concepts.h"
 
+// TODO: Improve JsonError to allow for more context, i.e. the error
+// can note the full "path" in the JSON tree where the error occurred
+
+//-Macros------------------------------------------------------------------
+/*! @cond */
+#define __QX_JSON_META_STRUCT(meta_tuple) \
+template <typename StructT> \
+struct QxJsonMetaStruct \
+{ \
+    static inline constexpr auto memberMetadata() \
+    { \
+        return meta_tuple; \
+    } \
+}
+
+#define __QX_JSON_MEMBER(member) QxJsonPrivate::makeMemberMetadata<#member>(&StructT::member)
+
+/*! @endcond */
+
+#define QX_JSON_STRUCT(...) __QX_JSON_META_STRUCT(std::make_tuple(QX_FOR_EACH_DELIM(__QX_JSON_MEMBER, __VA_ARGS__)))
+
+#define QX_JSON_DECLARE_MEMBER_OVERRIDES() \
+template<Qx::StringLiteral MemberN> \
+struct QxJsonConversionOverride
+
+#define QX_JSON_MEMBER_OVERRIDE(member, ...) \
+template<> \
+struct QxJsonConversionOverride<#member> \
+{ \
+    __VA_ARGS__\
+};
+
 namespace Qx
 {
 
+//-Concepts------------------------------------------------------------------------------------------------------
+class QX_CORE_EXPORT JsonError final : public AbstractError<"Qx::JsonError", 5>
+{
+//-Class Enums-------------------------------------------------------------
+public:
+    enum Form
+    {
+        NoError = 0,
+        MissingKey = 1,
+        TypeMismatch = 2,
+        EmptyDoc = 3,
+        InvalidValue = 4
+    };
+
+//-Class Variables-------------------------------------------------------------
+private:
+    static inline const QHash<Form, QString> ERR_STRINGS{
+        {NoError, QSL("")},
+        {MissingKey, QSL("The key does not exist.")},
+        {TypeMismatch, QSL("Value type mismatch.")},
+        {EmptyDoc, QSL("The document is empty.")},
+        {InvalidValue, QSL("Invalid value for type.")}
+    };
+
+    QString mAction;
+    Form mForm;
+
+//-Class Constructor-------------------------------------------------------------
+public:
+    JsonError();
+    JsonError(const QString& a, Form f);
+
+//-Class Functions-------------------------------------------------------------
+public:
+    bool isValid() const;
+    QString action() const;
+    Form form() const;
+
+private:
+    quint32 deriveValue() const override;
+    QString derivePrimary() const override;
+    QString deriveSecondary() const override;
+};
+
+QX_CORE_EXPORT QList<QJsonValue> findAllValues(const QJsonValue& rootValue, QStringView key);
+QX_CORE_EXPORT QString asString(const QJsonValue& value);
+
+} // namespace Qx
+
+/*! @cond */
+namespace QxJsonPrivate
+{
+//-Namespace Variables---------------------------------------------------
+static inline const QString ERR_CONV_TYPE = QSL("JSON Error: Converting value to %1");
+static inline const QString ERR_NO_KEY = QSL("JSON Error: Could not retrieve key '%1'.");
+static inline const QString ERR_PARSE_DOC = QSL("JSON Error: Could not parse JSON document.");
+
+//-Structs---------------------------------------------------------------
+template<Qx::StringLiteral MemberN, typename MemberT, class Struct>
+struct MemberMetadata
+{
+    constexpr static Qx::StringLiteral M_NAME = MemberN;
+    typedef MemberT M_TYPE;
+    MemberT Struct::* mPtr;
+};
+
+//-Functions-------------------------------------------------------------
+template <Qx::StringLiteral N, typename T, class S>
+constexpr MemberMetadata<N, T, S> makeMemberMetadata(T S::*memberPtr)
+{
+    return {memberPtr};
+}
+
+template<typename T> static inline QString typeString() = delete;
+template<typename T> static inline bool isType(const QJsonValue& v) = delete;
+template<typename T> static inline T toType(const QJsonValue& v) = delete;
+
+template<> inline QString typeString<bool>() { return QSL("bool"); };
+template<> inline QString typeString<double>() { return QSL("double"); };
+template<> inline QString typeString<QString>() { return QSL("string"); };
+template<> inline QString typeString<QJsonArray>() { return QSL("array"); };
+template<> inline QString typeString<QJsonObject>() { return QSL("object"); };
+
+template<> inline bool isType<bool>(const QJsonValue& v) { return v.isBool(); };
+template<> inline bool isType<double>(const QJsonValue& v) { return v.isDouble(); };
+template<> inline bool isType<QString>(const QJsonValue& v) { return v.isString(); };
+template<> inline bool isType<QJsonArray>(const QJsonValue& v) { return v.isArray(); };
+template<> inline bool isType<QJsonObject>(const QJsonValue& v) { return v.isObject(); };
+
+template<> inline bool toType<bool>(const QJsonValue& v) { return v.toBool(); };
+template<> inline double toType<double>(const QJsonValue& v) { return v.toDouble(); };
+template<> inline QString toType<QString>(const QJsonValue& v) { return v.toString(); };
+template<> inline QJsonArray toType<QJsonArray>(const QJsonValue& v) { return v.toArray(); };
+template<> inline QJsonObject toType<QJsonObject>(const QJsonValue& v) { return v.toObject(); };
+
+} // namespace QxJsonPrivate
+/*! @endcond */
+
+namespace QxJson
+{
+//-Structs---------------------------------------------------------------
+template<typename T>
+struct Converter;
+
+//-Concepts--------------------------------------------------------------
 template<typename T>
 concept qjson_type = Qx::any_of<T, bool, double, QString, QJsonArray, QJsonObject>;
 
-class QX_CORE_EXPORT Json
-{
-//-Inner Classes-------------------------------------------------------------------------------------------------
-public:
-    class QX_CORE_EXPORT Error final : public AbstractError<"Qx::Json::Error", 5>
-    {
-    public:
-        enum Form
-        {
-            NoError = 0,
-            MissingKey = 1,
-            TypeMismatch = 2
-        };
-
-    private:
-        static inline const QHash<Form, QString> ERR_STRINGS{
-            {NoError, QSL("")},
-            {MissingKey, QSL("The key does not exist.")},
-            {TypeMismatch, QSL("Value type mismatch.")}
-        };
-
-        QString mAction;
-        Form mForm;
-
-    public:
-        Error(const QString& a = {}, Form f = NoError);
-
-        QString action() const;
-        Form form() const;
-
-    private:
-        quint32 deriveValue() const override;
-        QString derivePrimary() const override;
-        QString deriveSecondary() const override;
-    };
-
-//-Class Members-------------------------------------------------------------------------------------------------
-private:
-    // Errors
-    static inline const QString ERR_RETRIEVING_VALUE = QSL("JSON Error: Could not retrieve the %1 value from key '%2'.");
-    static inline const QString ERR_CONVERTING_ARRAY_LIST = QSL("JSON Error: Could not convert JSON array to a list of %1.");
-    static inline const QString ERR_CONVERTING_ARRAY_SET = QSL("JSON Error: Could not convert JSON array to a set of %1.");
-
-//-Class Functions-----------------------------------------------------------------------------------------------
-private:
-    template<typename T> static inline QString typeString() = delete;
-    template<typename T> static inline bool isType(const QJsonValue& v) = delete;
-    template<typename T> static inline const T toType(const QJsonValue& v) = delete;
-
-public:
-    template<typename T>
-        requires qjson_type<T>
-    static Error checkedKeyRetrieval(T& valueBuffer, const QJsonObject& jObject, QStringView key)
-    {
-        // Reset buffer
-        valueBuffer = T();
-
-        QJsonValue jv;
-
-        if((jv = jObject.value(key)).isUndefined())
-            return Error{.action = ERR_RETRIEVING_VALUE.arg(typeString<T>(), key), .form = Error::MissingKey};
-
-        if(!isType<T>(jv))
-        {
-            QString ts = typeString<T>();
-            return Error(ERR_RETRIEVING_VALUE.arg(ts, key), Error::TypeMismatch);
-        }
-        else
-            valueBuffer = toType<T>(jv);
-
-        return Error();
-    }
-
-    template<typename T>
-        requires qjson_type<T>
-    static Error checkedArrayConversion(QList<T>& valueBuffer, const QJsonArray& jArray)
-    {
-        // Reset buffer
-        valueBuffer.clear();
-
-        for(const QJsonValue& value : jArray)
-        {
-            if(isType<T>(value))
-                valueBuffer.append(toType<T>(value));
-            else
-            {
-                valueBuffer.clear();
-                QString ts = typeString<T>();
-                return Error(ERR_CONVERTING_ARRAY_LIST.arg(ts), Error::TypeMismatch);
-            }
-        }
-
-        return Error();
-    }
-
-    template<typename T>
-        requires qjson_type<T>
-    static Error checkedArrayConversion(QSet<T>& valueBuffer, const QJsonArray& jArray)
-    {
-        // Reset buffer
-        valueBuffer.clear();
-
-        for(const QJsonValue& value : jArray)
-        {
-            if(isType<T>(value))
-                valueBuffer.insert(toType<T>(value));
-            else
-            {
-                valueBuffer.clear();
-                QString ts = typeString<T>();
-                return Error(ERR_CONVERTING_ARRAY_SET.arg(ts), Error::TypeMismatch);
-            }
-        }
-
-        return Error();
-    }
-
-    static QList<QJsonValue> findAllValues(const QJsonValue& rootValue, QStringView key);
-
-    static QString asString(const QJsonValue& value);
+template<typename T>
+concept json_struct = requires {
+    T::template QxJsonMetaStruct<T>::memberMetadata();
 };
 
-/* Template specializations
- *
- * The C++03 standard used to state that member (i.e. in class) explicit template
- * specializations had to be declared within the enclosing scope of the class, instead
- * of within the class itself. This was then updated in C++17 so that the latter is legal.
- *
- * However, while it does work for MSVC and Clang, GCC still hasn't met compliance with the
- * change and so this old requirement must still be met in order to maintain wide compiler
- * compatibility
- *
- * See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282
- */
-template<> inline QString Json::typeString<bool>() { return QSL("bool"); };
-template<> inline QString Json::typeString<double>() { return QSL("double"); };
-template<> inline QString Json::typeString<QString>() { return QSL("string"); };
-template<> inline QString Json::typeString<QJsonArray>() { return QSL("array"); };
-template<> inline QString Json::typeString<QJsonObject>() { return QSL("object"); };
+template<typename T>
+concept json_convertible = requires(T& tValue) {
+    { Converter<T>::fromJson(tValue, QJsonValue()) } -> std::same_as<Qx::JsonError>;
+};
 
-template<> inline bool Json::isType<bool>(const QJsonValue& v) { return v.isBool(); };
-template<> inline bool Json::isType<double>(const QJsonValue& v) { return v.isDouble(); };
-template<> inline bool Json::isType<QString>(const QJsonValue& v) { return v.isString(); };
-template<> inline bool Json::isType<QJsonArray>(const QJsonValue& v) { return v.isArray(); };
-template<> inline bool Json::isType<QJsonObject>(const QJsonValue& v) { return v.isObject(); };
+template<class K, typename T, Qx::StringLiteral N>
+concept json_override_convertible = requires(T& tValue) {
+    { K::template QxJsonConversionOverride<N>::fromJson(tValue, QJsonValue()) } -> std::same_as<Qx::JsonError>;
+};
 
-template<> inline const bool Json::toType<bool>(const QJsonValue& v) { return v.toBool(); };
-template<> inline const double Json::toType<double>(const QJsonValue& v) { return v.toDouble(); };
-template<> inline const QString Json::toType<QString>(const QJsonValue& v) { return v.toString(); };
-template<> inline const QJsonArray Json::toType<QJsonArray>(const QJsonValue& v) { return v.toArray(); };
-template<> inline const QJsonObject Json::toType<QJsonObject>(const QJsonValue& v) { return v.toObject(); };
+template<typename Key, class Value>
+Key keygen(const Value& value) = delete;
 
+template<typename Key, class Value>
+concept json_keyable = requires(const Value& v) {
+    { keygen<Key, Value>(v) } -> std::same_as<Key>;
+};
+
+template<typename T>
+concept containing = Qx::specializes<T, QList> ||
+                     Qx::specializes<T, QSet>;
+
+template<typename T>
+concept json_containing = containing<T> &&
+                          json_convertible<typename T::parameter_type>;
+
+template<typename T>
+concept associative = Qx::specializes<T, QHash> ||
+                      Qx::specializes<T, QMap>;
+
+template<typename T>
+concept json_associative = associative<T> &&
+                           json_convertible<typename T::mapped_type> &&
+                           json_keyable<typename T::key_type, typename T::mapped_type>;
+
+//-Default Converter Specializations-------------------------------------
+/*! @cond */
+template<typename T>
+    requires qjson_type<T>
+struct Converter<T>
+{
+    static Qx::JsonError fromJson(T& value, const QJsonValue& jValue)
+    {
+        if(!QxJsonPrivate::isType<T>(jValue))
+            return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<T>()), Qx::JsonError::TypeMismatch);
+
+        value = QxJsonPrivate::toType<T>(jValue);
+        return Qx::JsonError();
+    }
+};
+
+template<typename T>
+    requires json_struct<T>
+struct Converter<T>
+{
+    static Qx::JsonError fromJson(T& value, const QJsonValue& jValue)
+    {
+        if(!jValue.isObject())
+            return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<QJsonObject>()), Qx::JsonError::TypeMismatch);
+
+        // Underlying object
+        QJsonObject jObject = jValue.toObject();
+
+        // Error tracker
+        Qx::JsonError cnvError;
+
+        // Get member metadata tuple
+        constexpr auto memberMetas = T::template QxJsonMetaStruct<T>::memberMetadata();
+
+        // "Iterate" over each tuple element via std::apply, with a fold expression
+        // utilizing && which short-circuits. This allows us to "break" the loop
+        // upon a member conversion failure as single return of false in the inner-most
+        // lambda will trigger the short-circuit.
+        std::apply([&](auto&&... memberMeta) constexpr {
+            // Fold expression
+            ([&]{
+                // Meta
+                constexpr auto mName = memberMeta.M_NAME;
+                QLatin1StringView mKey(mName.value);
+                using mType = typename std::remove_reference<decltype(memberMeta)>::type::M_TYPE;
+                auto mPtr = memberMeta.mPtr;
+
+                // Get value from key
+                if(!jObject.contains(mKey))
+                {
+                    cnvError = Qx::JsonError(QxJsonPrivate::ERR_NO_KEY.arg(mKey), Qx::JsonError::MissingKey);
+                    return false;
+                }
+                QJsonValue mValue = jObject.value(mKey);
+
+                // Convert value
+                if constexpr(json_override_convertible<T, mType, mName>)
+                    cnvError = T::template QxJsonConversionOverride<mName>::fromJson(value.*mPtr, mValue);
+                else
+                    cnvError = Converter<mType>::fromJson(value.*mPtr, mValue);
+
+                return !cnvError.isValid();
+            }() && ...);
+        }, memberMetas);
+
+        return cnvError;
+    }
+};
+
+template<typename T>
+    requires json_containing<T>
+struct Converter<T>
+{
+    using E = typename T::parameter_type;
+
+    static Qx::JsonError fromJson(T& value, const QJsonValue& jValue)
+    {
+        // Reset buffer
+        value.clear();
+
+        if(!jValue.isArray())
+            return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<QJsonArray>()), Qx::JsonError::TypeMismatch);
+
+        // Underlying Array
+        QJsonArray jArray = jValue.toArray();
+
+        // Error tracking
+        Qx::JsonError cnvError;
+
+        // Convert all
+        for(const QJsonValue& aValue : jArray)
+        {
+            E converted;
+            if(cnvError = Converter<E>::fromJson(converted, aValue); cnvError.isValid())
+            {
+                value.clear();
+                return cnvError;
+            }
+
+            value << converted;
+        }
+
+        return Qx::JsonError();
+    }
+};
+
+template<typename T>
+    requires json_associative<T>
+struct Converter<T>
+{
+    static Qx::JsonError fromJson(T& value, const QJsonValue& jValue)
+    {
+        using K = typename T::key_type;
+        using V = typename T::mapped_type;
+
+        // Reset buffer
+        value.clear();
+
+        if(!jValue.isArray())
+            return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<QJsonArray>()), Qx::JsonError::TypeMismatch);
+
+        // Underlying Array
+        QJsonArray jArray = jValue.toArray();
+
+        // Error tracking
+        Qx::JsonError cnvError;
+
+        // Convert all
+        for(const QJsonValue& aValue : jArray)
+        {
+            K converted;
+            if(cnvError = Converter<V>::fromJson(converted, aValue); cnvError.isValid())
+            {
+                value.clear();
+                return cnvError;
+            }
+
+            value.insert(keygen(converted), converted);
+        }
+
+        return Qx::JsonError();
+    }
+};
+
+template<typename T>
+    requires std::integral<T> && (!std::same_as<T, bool>)
+struct Converter<T>
+{
+    static Qx::JsonError fromJson(T& value, const QJsonValue& jValue)
+    {
+        if(!jValue.isDouble())
+            return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<double>()), Qx::JsonError::TypeMismatch);
+
+        value = static_cast<T>(jValue.toDouble());
+        return Qx::JsonError();
+    }
+};
+
+} // namespace QxJson
+
+namespace Qx
+{
+
+//-Concepts (cont.)-------------------------------------------------------------------------------------------------
+template<typename T>
+concept json_root = QxJson::json_containing<T> ||
+                    QxJson::json_struct<T>;
+
+//-Functions-------------------------------------------------------------------------------------------------------
+template<typename T>
+    requires json_root<T>
+JsonError parseJson(T& parsed, const QJsonDocument& doc)
+{
+    if(doc.isEmpty())
+        return JsonError(QxJsonPrivate::ERR_PARSE_DOC, JsonError::EmptyDoc);
+
+    using RootType = std::conditional_t<
+        (QxJson::json_containing<T>), QJsonArray, QJsonObject>;
+
+    RootType root;
+    if constexpr(QxJson::json_containing<T>)
+    {
+        if(!doc.isArray())
+            return JsonError(QxJsonPrivate::ERR_PARSE_DOC, JsonError::TypeMismatch);
+
+        root = doc.array();
+    }
+    else
+    {
+        if(!doc.isObject())
+            return JsonError(QxJsonPrivate::ERR_PARSE_DOC, JsonError::TypeMismatch);
+
+        root = doc.object();
+    }
+
+    // Use QJsonValue move constructor for semi-type erasure
+    QJsonValue rootAsValue = std::move(root);
+
+    return QxJson::Converter<T>::fromJson(parsed, rootAsValue);
 }
+/*! @endcond */
+
+} // namespace Qx
+
 
 #endif // QX_JSON_H

--- a/lib/core/src/qx-json.cpp
+++ b/lib/core/src/qx-json.cpp
@@ -13,131 +13,124 @@
  *  @ingroup qx-core
  *
  *  @brief The qx-json header file provides various utilities for JSON data manipulation.
+ *
+ *  The mechanisms of this file introduce a highly flexible, simple to use, declarative
+ *  mechanism for parsing JSON data into user structs and other types.
+ *
+ *  For example, the following JSON data:
+ *  @snippet qx-json.cpp 0
+ *
+ *  can easily be parsed into a corresponding set of C++ data structures like so:
+ *  @snippet qx-json.cpp 1
+ *
+ *  @sa QX_JSON_STRUCT(), and QxJson.
+ */
+
+/*!
+ *  @def QX_JSON_STRUCT()
+ *
+ *  Specifies that a struct is a JSON-tied struct, which enables support for automatic
+ *  parsing of a corresponding JSON object.
+ *
+ *  The name of each included member must match the name their corresponding JSON key.
+ *
+ *  @snippet qx-json.cpp 2
+ */
+
+/*!
+ *  @def QX_JSON_DECLARE_MEMBER_OVERRIDES()
+ *
+ *  Declares that a JSON-tried struct has member/key specific value parsing overrides.
+ *
+ *  This macro must be used before any member specific overrides can be defined.
+ *
+ *  @sa QX_JSON_MEMBER_OVERRIDE()
+ */
+
+/*!
+ *  @def QX_JSON_MEMBER_OVERRIDE()
+ *
+ *  Used to define a member/key specific value parsing override for a JSON-tried struct.
+ *  The specified member will be parsed using the provided function instead of a
+ *  potentially available generic one for that type.
+ *
+ *  @snippet qx-json.cpp 3
  */
 
 namespace Qx
 {
 
-/*!
- *  @concept qjson_type
- *  @brief Specifies that a type is one of the set used for within JSON related Qt classes.
- *
- *  Satisfied if @a T is one of:
- *  - bool
- *  - double
- *  - QString
- *  - QJsonArray
- *  - QJsonObject
- */
-
 //===============================================================================================================
-// Json::Error
+// JsonError
 //===============================================================================================================
 
 // Enum
 /*!
- *  @class Json::Error qx/core/qx-json.h
+ *  @class JsonError qx/core/qx-json.h
  *
- *  @brief The Json::Error class is used to report errors related to JSON manipulation.
+ *  @brief The JsonError class is used to report errors related to JSON manipulation.
  */
 
 /*!
- *  @enum Json::Error::Form
+ *  @enum JsonError::Form
  *
  *  This enum represents form of JSON error.
  */
 
 /*!
- *  @var Json::Error::Form Json::Error::NoError
+ *  @var JsonError::Form JsonError::NoError
  *  No error occurred.
  */
 
 /*!
- *  @var Json::Error::Form Json::Error::MissingKey
+ *  @var JsonError::Form JsonError::MissingKey
  *  An expected key was missing.
  */
 
 // Ctor
-Json::Error::Error(const QString& a, Form f) :
+/*!
+ *  Creates an invalid JsonError.
+ */
+JsonError::JsonError() :
+    mAction(),
+    mForm(Form::NoError)
+{}
+
+/*!
+ *  Creates a JSON error with the action @a and error form @a f.
+ */
+JsonError::JsonError(const QString& a, Form f) :
     mAction(a),
     mForm(f)
 {}
 
 // Functions
 /*!
+ *  Returns @c true if an error occurred; otherwise, returns @c false.
+ */
+bool JsonError::isValid() const { return mForm != NoError; }
+
+/*!
  *  A message noting the attempted action that failed.
  */
-QString Json::Error::action() const { return mAction; }
+QString JsonError::action() const { return mAction; }
 
 /*!
  *  The form of error that occurred.
  */
-Json::Error::Form Json::Error::form() const { return mForm; }
+JsonError::Form JsonError::form() const { return mForm; }
 
 // Functions
-quint32 Json::Error::deriveValue() const { return mForm; };
-QString Json::Error::derivePrimary() const { return mAction; };
-QString Json::Error::deriveSecondary() const { return ERR_STRINGS.value(mForm); };
+quint32 JsonError::deriveValue() const { return mForm; };
+QString JsonError::derivePrimary() const { return mAction; };
+QString JsonError::deriveSecondary() const { return ERR_STRINGS.value(mForm); };
 
 //===============================================================================================================
-// Json
+// <namepace>
 //===============================================================================================================
 
-/*!
- *  @class Json qx/core/qx-json.h
- *  @ingroup qx-core
- *
- *  @brief The Json class is a collection of static functions pertaining to parsing JSON data
- */
-
-//-Class Functions---------------------------------------------------------------------------------------------
+//-Functions---------------------------------------------------------------------------------------------
 //Public:
-
-/*!
- *  @fn Json::Error Json::checkedKeyRetrieval(T& valueBuffer, const QJsonObject& jObject, const QString& key)
- *
- *  Safely retrieves the value associated with the specified key from the given JSON Object.
- *
- *  Before the value data is accessed a check is performed to ensure that the key actually exists and that the
- *  type of the value matches the expected type @a T. This precludes the need to perform these two steps independently
- *  for every key/value pair parsed from a JSON Object.
- *
- *  @param[out] valueBuffer The return buffer for the retrieved value.
- *  @param[in] jObject The JSON Object to retrieve a value from.
- *  @param[in] key The key associated with the desired value.
- *
- *  If the key doesn't exist, or the type of that key's value is not the same as the return value buffer's type,
- *  the returned error object will specify such; otherwise, an invalid error is returned.
- *
- *  @a valueBuffer is set to a default constructed value in the event of an error.
- */
-
-/*!
- *  @fn Json::Error Json::checkedArrayConversion(QList<T>& valueBuffer, const QJsonArray& jArray)
- *
- *  Safely transforms the provided JSON array into a list of values of its underlying type.
- *
- *  This assumes that the array is homogeneous.
- *
- *  @param[out] valueBuffer The return buffer for the retrieved value.
- *  @param[in] jArray The JSON Object to retrieve a value from.
- *
- *  If array contains a value that does not match the return value buffer's type,
- *  the returned error object will specify such; otherwise, an invalid error is returned.
- *
- *  @a valueBuffer is set to an empty list in the event of an error.
- */
-
-/*!
- * @fn Json::Error Json::checkedArrayConversion(QSet<T>& valueBuffer, const QJsonArray& jArray)
- *
- * @overload
- *
- * Safely transforms the provided JSON array into a set of values of its underlying type.
- *
- * @a valueBuffer is set to an empty set in the event of an error.
- */
-
 /*!
  *  Recursively searches @a rootValue for @a key and returns the associated value for
  *  all matches as a list, or an empty list if the key was not found.
@@ -145,7 +138,7 @@ QString Json::Error::deriveSecondary() const { return ERR_STRINGS.value(mForm); 
  *  If @a rootValue is of any type other than QJsonValue::Array or QJsonValue::Object
  *  then returned list will always be empty.
  */
-QList<QJsonValue> Json::findAllValues(const QJsonValue& rootValue, QStringView key)
+QList<QJsonValue> findAllValues(const QJsonValue& rootValue, QStringView key)
 {
     QList<QJsonValue> hits;
     recursiveValueFinder(hits, rootValue, key);
@@ -157,7 +150,7 @@ QList<QJsonValue> Json::findAllValues(const QJsonValue& rootValue, QStringView k
  *
  *  If @a value is an object or array, the returned string will be in the compact format.
  */
-QString Json::asString(const QJsonValue& value)
+QString asString(const QJsonValue& value)
 {
     QJsonValue::Type valueType = value.type();
     if(valueType == QJsonValue::Type::Array)
@@ -178,6 +171,64 @@ QString Json::asString(const QJsonValue& value)
         return value.toString();
     else // Covers Null & Undefined
         return QString();
+} // namespace Qx
+
+namespace QxJson
+{
+//===============================================================================================================
+// <namepace>
+//===============================================================================================================
+
+/*!
+ *  @namespace QxJson
+ *
+ *  @brief The @c QxJson namespace encapsulates the user-extensible implementation of Qx's JSON parsing facilities.
+ */
+
+/*!
+ *  @struct Converter
+ *
+ *  @brief The Converter template struct acts as an interface that carries details on how to parse JSON to various types.
+ *
+ *  JSON data can be converted to an object of any type as Converter provides a specialization for that type that
+ *  contains a corresponding fromJson() function.
+ *
+ *  By default, conversions are provided for:
+ *  - bool
+ *  - double
+ *  - Integer Types
+ *  - QString
+ *  - QJsonArray
+ *  - QJsonObject
+ *  - QList<T>
+ *  - QSet<T>
+ *  - QHash<K, T> (when a keygen() specialization exists for K)
+ *  - QMap<K, T> (when a keygen() specialization exists for K)
+ *
+ *  Support for additional, non-structural types can be added like so:
+ *  @snippet qx-json.cpp 4
+ *
+ *  If a structural type needs to be registered, the QX_JSON_STRUCT and QX_JSON_MEMBER macros should be used
+ *  instead.
+ *
+ *  @sa qx-json.h and keygen().
+ */
+
+/*!
+ *  @fn template<typename Key, class Value> Key keygen(const Value& value)
+ *
+ *  @brief The keygen template function acts as an interface through which the derivation of a key
+ *  for a given type when used in associative containers is defined.
+ *
+ *  Any otherwise convertible JSON type can be parsed into a map as long as a specialization of keygen() exists
+ *  for that type.
+ *
+ *  Support for additional types can be added like so:
+ *  @snippet qx-json.cpp 5
+ *
+ *  @sa qx-json.h and Converter.
+ */
+
 }
 
 }

--- a/lib/utility/CMakeLists.txt
+++ b/lib/utility/CMakeLists.txt
@@ -1,5 +1,6 @@
 #================= Add Component ==========================
 qx_add_component("Utility"
+    TARGET_VAR utility_target
     HEADERS_API
         qx-concepts.h
         qx-helpers.h
@@ -11,3 +12,9 @@ qx_add_component("Utility"
         qx-macros.dox
         qx-stringliteral.dox
 )
+
+# Force conforming preprocessor for MSVC, required for
+# some macros (e.g. QX_FOR_EACH) to work
+if(MSVC)
+    target_compile_options(${utility_target} INTERFACE "/Zc:preprocessor")
+endif()

--- a/lib/utility/include/qx/utility/qx-concepts.h
+++ b/lib/utility/include/qx/utility/qx-concepts.h
@@ -6,6 +6,22 @@
 #include <iterator>
 #include <type_traits>
 
+/*! @cond */
+namespace QxConceptsPrivate
+{
+
+template <class A, template <typename...> class B>
+struct is_specialization_of : std::false_type {};
+
+template <typename... Args, template <typename...> class B>
+struct is_specialization_of<B<Args...>, B> : std::true_type {};
+
+template <typename A, template <typename...> class B>
+inline constexpr bool is_specialization_of_v = is_specialization_of<A, B>::value;
+
+}
+/*! @endcond */
+
 namespace Qx
 {
 
@@ -491,6 +507,10 @@ concept static_castable_to = requires(K klass) {{ static_cast<T>(klass) };};
 // Grouping
 template<class K, class ... L>
 concept any_of = (std::same_as<K, L> || ...);
+
+// Template
+template<typename K, template <typename...> class L>
+concept specializes = QxConceptsPrivate::is_specialization_of_v<K, L>;
 
 }
 

--- a/lib/utility/include/qx/utility/qx-macros.h
+++ b/lib/utility/include/qx/utility/qx-macros.h
@@ -1,6 +1,34 @@
 #ifndef QX_MACROS_H
 #define QX_MACROS_H
 
+// Helper
+/*! @cond */
+#define __QX_MACRO_EXPAND1(...) __VA_ARGS__
+#define __QX_MACRO_EXPAND2(...) __QX_MACRO_EXPAND1(__QX_MACRO_EXPAND1(__VA_ARGS__))
+#define __QX_MACRO_EXPAND4(...) __QX_MACRO_EXPAND2(__QX_MACRO_EXPAND2(__VA_ARGS__))
+#define __QX_MACRO_EXPAND8(...) __QX_MACRO_EXPAND4(__QX_MACRO_EXPAND4(__VA_ARGS__))
+#define __QX_MACRO_EXPAND16(...) __QX_MACRO_EXPAND8(__QX_MACRO_EXPAND8(__VA_ARGS__))
+#define __QX_MACRO_EXPAND32(...) __QX_MACRO_EXPAND8(__QX_MACRO_EXPAND8(__VA_ARGS__))
+#define __QX_MACRO_EXPAND64(...) __QX_MACRO_EXPAND8(__QX_MACRO_EXPAND8(__VA_ARGS__))
+#define __QX_MACRO_EXPAND128(...) __QX_MACRO_EXPAND8(__QX_MACRO_EXPAND8(__VA_ARGS__))
+#define __QX_MACRO_EXPAND256(...) __QX_MACRO_EXPAND8(__QX_MACRO_EXPAND8(__VA_ARGS__))
+#define __QX_MACRO_EVALUATE(...) __QX_MACRO_EXPAND256(__VA_ARGS__)
+
+#define __QX_MACRO_CALL ()
+
+#define __QX_FOR_EACH_NEXT() __QX_FOR_EACH_APPLY_AND_ITERATE
+#define __QX_FOR_EACH_NEXT_DELIM() __QX_FOR_EACH_APPLY_AND_ITERATE_DELIM
+
+#define __QX_FOR_EACH_APPLY_AND_ITERATE(macro, first, ...) \
+    macro(first) \
+    __VA_OPT__(__QX_FOR_EACH_NEXT __QX_MACRO_CALL (macro, __VA_ARGS__))
+
+#define __QX_FOR_EACH_APPLY_AND_ITERATE_DELIM(macro, first, ...) \
+    macro(first) \
+    __VA_OPT__(, __QX_FOR_EACH_NEXT_DELIM __QX_MACRO_CALL (macro, __VA_ARGS__))
+/*! @endcond */
+
+// User
 #define QX_SCOPED_ENUM_HASH_FUNC(T) \
 inline size_t qHash(const T& t, size_t seed) { \
     return ::qHash(static_cast<typename std::underlying_type<T>::type>(t), seed); \
@@ -8,5 +36,11 @@ inline size_t qHash(const T& t, size_t seed) { \
 
 #define QSL QStringLiteral
 #define QBAL QByteArrayLiteral
+
+#define QX_FOR_EACH(macro, ...) \
+    __VA_OPT__(__QX_MACRO_EVALUATE(__QX_FOR_EACH_APPLY_AND_ITERATE(macro, __VA_ARGS__)))
+
+#define QX_FOR_EACH_DELIM(macro, ...) \
+    __VA_OPT__(__QX_MACRO_EVALUATE(__QX_FOR_EACH_APPLY_AND_ITERATE_DELIM(macro, __VA_ARGS__)))
 
 #endif // QX_MACROS_H

--- a/lib/utility/src/qx-concepts.dox
+++ b/lib/utility/src/qx-concepts.dox
@@ -1108,4 +1108,20 @@ namespace Qx
  *
  *  Satisfied if @c K can be converted to @c T using static_cast<>().
  */
+
+// Grouping
+/*!
+ *  @concept any_of
+ *  @brief Specifies that a type is one of several types.
+ *
+ *  Satisfied if @c K is the same as at least one of @c L.
+ */
+
+// Template
+/*!
+ *  @concept specializes
+ *  @brief Specifies that a type is a specialization of a template.
+ *
+ *  Satisfied if @c K is a specialization of @c L with any parameters.
+ */
 }

--- a/lib/utility/src/qx-macros.dox
+++ b/lib/utility/src/qx-macros.dox
@@ -23,3 +23,30 @@
  *
  *  This convenience macro is an alias for QByteArrayLiteral.
  */
+
+/*!
+ *  @def QX_FOR_EACH(macro, ...)
+ *
+ *  This function-like macro acts like a fold expression for its variadic arguments.
+ *  It produces the result of calling the macro @a macro once for each argument that
+ *  follows.
+ *
+ *  For example:
+ *  @code{.cpp}
+ *  #define F(x) //...
+ *  QX_FOR_EACH(F, 1, 4, 10) // -> F(1) F(4) F(10)
+ *  @endcode
+ *
+ *  @sa QX_FOR_EACH_DELIM()
+ */
+
+/*!
+ *  @def QX_FOR_EACH_DELIM(macro, ...)
+ *
+ *  Same as QX_FOR_EACH(), but a comma in placed between each resultant element.
+ *
+ *  @code{.cpp}
+ *  #define F(x) //...
+ *  QX_FOR_EACH_DELIM(F, 1, 4, 10) // -> F(1), F(4), F(10)
+ *  @endcode
+ */


### PR DESCRIPTION
Add ability to parse arbitrary user structs via the use of declarative
macros placed within said structs that simply re-list the data members
of the struct.

By using QX_JSON_STRUCT(...) where ... is a list of QX_JSON_MEMBER macro
invocations that use the name of the structs data members, one can make
that struct directly parseable as if it as a JSON object.

The name of members must match the name of their corresponding key in
actual JSON data.

There is much to improve in terms of simplifying the macro requirements
(i.e. dropping requirement of inner macro) and adding flexibility (like
handling derived structs and allowing for members to be associated with
one), but for now it's very usable
as is.

This commit also removes the Json class, only moving a few of its
functions to the Qx namespace, as most of its functionality is made
obsolete by these new facilities.