### PR TITLE
Make QX_JSON_MEMBER_OVERRIDE() struct external

### DIFF
--- a/lib/core/doc/res/snippets/qx-json.cpp
+++ b/lib/core/doc/res/snippets/qx-json.cpp
@@ -94,18 +94,16 @@ struct MySpecialStruct
     int number;
     QString name;
     
-    QX_JSON_STRUCT(number, name);
-    
-    QX_JSON_DECLARE_MEMBER_OVERRIDES();
-    
-    QX_JSON_MEMBER_OVERRIDE(name,
-        static Qx::JsonError fromJson(QString& member, const QJsonValue& jv)
-        {
-            member = "OverridenName";
-            return Qx::JsonError();
-        }
-    )
+    QX_JSON_STRUCT(number, name);     
 }
+
+QX_JSON_MEMBER_OVERRIDE(MySpecialStruct, name,
+    static Qx::JsonError fromJson(QString& member, const QJsonValue& jv)
+    {
+        member = "OverridenName";
+        return Qx::JsonError();
+    }
+)
 //! [5]
 
 //! [6]

--- a/lib/core/include/qx/core/qx-json.h
+++ b/lib/core/include/qx/core/qx-json.h
@@ -242,8 +242,7 @@ namespace QxJsonPrivate
  * false branches are taken. Different compilers seem to discard the untaken
  * branch of the value dependent statement at different stages as it compiled
  * fine with MSVC and a newer version of GCC, but not clang or older GCC versions.
- * To clarify, compi
- * lation would fail due to the type in the not-yet-discarded
+ * To clarify, compilation would fail due to the type in the not-yet-discarded
  * branch not being declared.
  *
  * Putting the reference of the potentially undeclared types behind these functions
@@ -268,6 +267,13 @@ template<class K, typename T, Qx::StringLiteral N>
 Qx::JsonError performOverrideConversion(T& value, const QJsonValue& jv)
 {
     return K::template QxJsonConversionOverride<N>::fromJson(value, jv);
+}
+
+template<typename T>
+    requires QxJson::json_convertible<T>
+Qx::JsonError performRegularConversion(T& value, const QJsonValue& jv)
+{
+    return QxJson::Converter<T>::fromJson(value, jv);
 }
 /*! @endcond */
 
@@ -335,7 +341,7 @@ struct Converter<T>
                 if constexpr(json_override_convertible<T, mType, mName>)
                     cnvError = QxJsonPrivate::performOverrideConversion<T, mType, mName>(value.*mPtr, mValue);
                 else
-                    cnvError = Converter<mType>::fromJson(value.*mPtr, mValue);
+                    cnvError = QxJsonPrivate::performRegularConversion<mType>(value.*mPtr, mValue);
 
                 return !cnvError.isValid();
             }() && ...);

--- a/lib/core/src/qx-json.cpp
+++ b/lib/core/src/qx-json.cpp
@@ -89,15 +89,6 @@
  *  @sa QX_JSON_STRUCT_OUTSIDE()
  */
 
-/*!
- *  @def QX_JSON_DECLARE_MEMBER_OVERRIDES()
- *
- *  Declares that a JSON-tried struct has member/key specific value parsing overrides.
- *
- *  This macro must be used before any member specific overrides can be defined.
- *
- *  @sa QX_JSON_MEMBER_OVERRIDE()
- */
 
 /*!
  *  @def QX_JSON_MEMBER_OVERRIDE()
@@ -105,6 +96,8 @@
  *  Used to define a member/key specific value parsing override for a JSON-tried struct.
  *  The specified member will be parsed using the provided function instead of a
  *  potentially available generic one for that type.
+ *
+ *  Must be used in namespace scope, outside of the struct definition.
  *
  *  @snippet qx-json.cpp 5
  */


### PR DESCRIPTION
Allows for more flexibility and works around some non-conformance with Clang/GCC (class scope explicit template specialization).