### PR TITLE
Introduce serialization portion of qx-json

### DIFF
--- a/lib/core/doc/res/snippets/qx-json.cpp
+++ b/lib/core/doc/res/snippets/qx-json.cpp
@@ -41,10 +41,23 @@ int main()
     // Parse into custom structures
     Qx::JsonError je = Qx::parseJson(myJsonDoc, jsonFile);
     Q_ASSERT(!je.isValid());
+    
+    ...
 }
 //! [1]
 
 //! [2]
+int main()
+{
+    ...
+    
+    // Serialize to JSON
+    je = Qx::serializeJson(jsonFile, myJsonDoc);
+    Q_ASSERT(!je.isValid());
+}
+//! [2]
+
+//! [3]
 struct MyStruct
 {
     int number;
@@ -52,9 +65,9 @@ struct MyStruct
     
     QX_JSON_STRUCT(number, name);
 }
-//! [2]
-
 //! [3]
+
+//! [4]
 struct MyStruct
 {
     int number;
@@ -65,9 +78,9 @@ struct MyStruct
         QX_JSON_MEMBER_ALIASED(name, "aliasName")
     );
 }
-//! [3]
-
 //! [4]
+
+//! [5]
 struct MyStruct
 {
     int number;
@@ -76,9 +89,9 @@ struct MyStruct
 
 // At global scope
 QX_JSON_STRUCT_OUTSIDE(number, name);
-//! [4]
-
 //! [5]
+
+//! [6]
 struct MySpecialStruct
 {
     int number;
@@ -90,13 +103,20 @@ struct MySpecialStruct
 QX_JSON_MEMBER_OVERRIDE(MySpecialStruct, name,
     static Qx::JsonError fromJson(QString& member, const QJsonValue& jv)
     {
-        member = "OverridenName";
+        // Add prefix when parsing
+        member = "Prefix" + jv.toString();
         return Qx::JsonError();
     }
+    
+    static QString toJson(const QString& member)
+    {
+        // Remove prefix when serializing
+        return QString(member).remove("Prefix");
+    }
 )
-//! [5]
-
 //! [6]
+
+//! [7]
 QJsonArray ja;
 // Somehow populate array...
 
@@ -106,9 +126,9 @@ for(int i = 0; i < ja.size(); ++i)
     if(Qx::JsonError je = parseMyElement(ja[i]); je.isValid())
         return je.withContext(QxJson::Array()).withContext(QxJson::ArrayElement(i));
 }
-//! [6]
-
 //! [7]
+
+//! [8]
 class MyType
 {
     ...
@@ -127,11 +147,17 @@ namespace QxJson
             // Return an invalid JsonError upon success, or a valid one if an error occurs
             return Qx::JsonError();
         }
+        
+        static QJsonObject toJson(const MyType& value)
+        {
+            // Use value to return a valid JSON type (i.e. qjson_type concept)
+            return objFromMyType(value);
+        }
     };
 }
-//! [7]
-
 //! [8]
+
+//! [9]
 struct MyStruct
 {
     int number;
@@ -160,4 +186,4 @@ struct OtherStruct
     
     QX_JSON_STRUCT(enabled, myStructs);
 };
-//! [8]
+//! [9]

--- a/lib/core/include/qx/core/qx-json.h
+++ b/lib/core/include/qx/core/qx-json.h
@@ -24,30 +24,34 @@
 //-Macros------------------------------------------------------------------
 /*! @cond */
 #define __QX_JSON_META_STRUCT_INSIDE(meta_tuple) \
-    template <typename StructT> \
+template <typename StructT> \
     struct QxJsonMetaStructInside \
-    { \
+{ \
         static inline constexpr auto memberMetadata() \
-        { \
+    { \
             return meta_tuple; \
-        } \
-    }
+    } \
+}
 
 #define __QX_JSON_META_STRUCT_OUTSIDE(self_type, meta_tuple) \
 namespace QxJson \
 { \
-    template <typename StructT> \
-    struct QxJsonMetaStructOutside<self_type, StructT> \
+        template <typename StructT> \
+        struct QxJsonMetaStructOutside<self_type, StructT> \
     { \
-        static inline constexpr auto memberMetadata() \
+            static inline constexpr auto memberMetadata() \
         { \
-            return meta_tuple; \
+                return meta_tuple; \
         } \
     }; \
 }
 
 /*! @endcond */
 
+/* TODO: See if there is a magic way to have QX_JSON_STRUCT_X only require QX_JSON_MEMBER_ALIASED
+ * for each member the user wants to be aliased, but not require QX_JSON_MEMBER for members that
+ * are to have a default name
+ */
 #define QX_JSON_MEMBER(member) QxJsonPrivate::makeMemberMetadata<#member>(&StructT::member)
 #define QX_JSON_MEMBER_ALIASED(member, key) QxJsonPrivate::makeMemberMetadata<key>(&StructT::member)
 
@@ -68,10 +72,10 @@ namespace QxJson \
 #define QX_JSON_MEMBER_OVERRIDE(Struct, member, ...) \
 namespace QxJson \
 { \
-    template<> \
-    struct MemberOverrideCoverter<Struct, #member> \
+        template<> \
+        struct MemberOverrideCoverter<Struct, #member> \
     { \
-        __VA_ARGS__\
+            __VA_ARGS__\
     }; \
 }
 
@@ -150,7 +154,7 @@ namespace Qx
 
 class QX_CORE_EXPORT JsonError final : public AbstractError<"Qx::JsonError", 5>
 {
-//-Class Enums-------------------------------------------------------------
+    //-Class Enums-------------------------------------------------------------
 public:
     enum Form
     {
@@ -158,37 +162,37 @@ public:
         MissingKey,
         TypeMismatch,
         EmptyDoc,
-        InvalidValue,
         MissingFile,
         InaccessibleFile,
-        FileReadError
+        FileReadError,
+        FileWriteError
     };
 
-//-Class Variables-------------------------------------------------------------
+    //-Class Variables-------------------------------------------------------------
 private:
     static inline const QHash<Form, QString> ERR_STRINGS{
         {NoError, u""_s},
         {MissingKey, u"The key does not exist."_s},
         {TypeMismatch, u"Value type mismatch."_s},
         {EmptyDoc, u"The document is empty."_s},
-        {InvalidValue, u"Invalid value for type."_s},
         {MissingFile, u"File does not exist."_s},
         {InaccessibleFile, u"Cannot open the file."_s},
-        {FileReadError, u"File read error."_s}
+        {FileReadError, u"File read error."_s},
+        {FileWriteError, u"File write error."_s}
     };
 
-//-Instance Variables-------------------------------------------------------------
+    //-Instance Variables-------------------------------------------------------------
 private:
     QString mAction;
     Form mForm;
     QList<QxJson::ContextNode> mContext;
 
-//-Constructor-----------------------------------------------------------------
+    //-Constructor-----------------------------------------------------------------
 public:
     JsonError();
     JsonError(const QString& a, Form f);
 
-//-Instance Functions-------------------------------------------------------------
+    //-Instance Functions-------------------------------------------------------------
 private:
     quint32 deriveValue() const override;
     QString derivePrimary() const override;
@@ -213,6 +217,7 @@ static inline const QString ERR_CONV_TYPE = u"JSON Error: Converting value to %1
 static inline const QString ERR_NO_KEY = u"JSON Error: Could not retrieve key '%1'."_s;
 static inline const QString ERR_PARSE_DOC = u"JSON Error: Could not parse JSON document."_s;
 static inline const QString ERR_READ_FILE = u"JSON Error: Could not read JSON file."_s;
+static inline const QString ERR_WRITE_FILE = u"JSON Error: Could not write JSON file."_s;
 
 //-Structs---------------------------------------------------------------
 template<Qx::StringLiteral MemberN, typename MemberT, class Struct>
@@ -269,7 +274,6 @@ struct QxJsonMetaStructOutside;
 
 //-Concepts--------------------------------------------------------------
 
-// TODO: Document these concepts
 template<typename T>
 concept qjson_type = Qx::any_of<T, bool, double, QString, QJsonArray, QJsonObject>;
 
@@ -290,11 +294,13 @@ concept json_struct = json_struct_inside<T> ||
 template<typename T>
 concept json_convertible = requires(T& tValue) {
     { Converter<T>::fromJson(tValue, QJsonValue()) } -> std::same_as<Qx::JsonError>;
+    { Converter<T>::toJson(tValue) } -> qjson_type;
 };
 
 template<class K, typename T, Qx::StringLiteral N>
 concept json_override_convertible = requires(T& tValue) {
     { MemberOverrideCoverter<K, N>::fromJson(tValue, QJsonValue()) } -> std::same_as<Qx::JsonError>;
+    { MemberOverrideCoverter<K, N>::toJson(tValue) } -> qjson_type;
 };
 
 template<typename Key, class Value>
@@ -320,7 +326,7 @@ concept json_containing = json_collective<T> ||
 
 template<typename T>
 concept json_optional = Qx::specializes<T, std::optional> &&
-                        QxJson::json_convertible<typename T::value_type>;
+                        json_convertible<typename T::value_type>;
 
 } // namespace QxJson
 
@@ -344,6 +350,8 @@ namespace QxJsonPrivate
  *
  * Putting the reference of the potentially undeclared types behind these functions
  * that always exist solves the issue.
+ *
+ * These likely can be avoided with C++23's 'if consteval'.
  */
 template<class K>
     requires QxJson::json_struct_inside<K>
@@ -361,16 +369,30 @@ constexpr auto getMemberMeta()
 
 template<class K, typename T, Qx::StringLiteral N>
     requires QxJson::json_override_convertible<K, T, N>
-Qx::JsonError performOverrideConversion(T& value, const QJsonValue& jv)
+Qx::JsonError overrideParse(T& value, const QJsonValue& jv)
 {
     return QxJson::MemberOverrideCoverter<K, N>::fromJson(value, jv);
 }
 
+template<class K, typename T, Qx::StringLiteral N>
+    requires QxJson::json_override_convertible<K, T, N>
+auto overrideSerialize(const T& value)
+{
+    return QxJson::MemberOverrideCoverter<K, N>::toJson(value);
+}
+
 template<typename T>
     requires QxJson::json_convertible<T>
-Qx::JsonError performRegularConversion(T& value, const QJsonValue& jv)
+Qx::JsonError standardParse(T& value, const QJsonValue& jv)
 {
     return QxJson::Converter<T>::fromJson(value, jv);
+}
+
+template<typename T>
+    requires QxJson::json_convertible<T>
+auto standardSerialize(const T& value)
+{
+    return QxJson::Converter<T>::toJson(value);
 }
 /*! @endcond */
 
@@ -393,6 +415,16 @@ struct Converter<T>
         value = QxJsonPrivate::toType<T>(jValue);
         return Qx::JsonError();
     }
+
+    static T toJson(const T& value)
+    {
+        /* We could automatically box with QJsonValue here, but it's technically unnecessary as every possible
+         * type returned here is implicitly convertible to QJsonValue. Additionally, doing so would complicate
+         * the json_convertible concept as it would have to allow QJsonValue as well as the underlying
+         * types.
+         */
+        return value; // No-op
+    }
 };
 
 template<typename T>
@@ -403,7 +435,7 @@ struct Converter<T>
     {
         if(!jValue.isObject())
             return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<QJsonObject>()), Qx::JsonError::TypeMismatch)
-                   .withContext(QxJson::Object());
+                .withContext(QxJson::Object());
 
         // Underlying object
         QJsonObject jObject = jValue.toObject();
@@ -425,20 +457,20 @@ struct Converter<T>
                 static constexpr auto mName = std::remove_reference<decltype(memberMeta)>::type::M_NAME;
                 constexpr QLatin1StringView mKey(mName.value);
                 using mType = typename std::remove_reference<decltype(memberMeta)>::type::M_TYPE;
-                auto mPtr = memberMeta.mPtr;
+                auto& mRef = value.*(memberMeta.mPtr);
 
                 // Get value from key
                 if(!jObject.contains(mKey))
                 {
                     if constexpr(json_optional<mType>)
                     {
-                        value.*mPtr = std::nullopt;
+                        mRef = std::nullopt;
                         return true;
                     }
                     else
                     {
                         cnvError = Qx::JsonError(QxJsonPrivate::ERR_NO_KEY.arg(mKey), Qx::JsonError::MissingKey)
-                                       .withContext(QxJson::Object());
+                        .withContext(QxJson::Object());
                         return false;
                     }
                 }
@@ -446,9 +478,9 @@ struct Converter<T>
 
                 // Convert value
                 if constexpr(json_override_convertible<T, mType, mName>)
-                    cnvError = QxJsonPrivate::performOverrideConversion<T, mType, mName>(value.*mPtr, mValue);
+                    cnvError = QxJsonPrivate::overrideParse<T, mType, mName>(mRef, mValue);
                 else
-                    cnvError = QxJsonPrivate::performRegularConversion<mType>(value.*mPtr, mValue);
+                    cnvError = QxJsonPrivate::standardParse<mType>(mRef, mValue);
 
                 cnvError.withContext(QxJson::ObjectKey(mKey)).withContext(QxJson::Object());
                 return !cnvError.isValid();
@@ -456,6 +488,42 @@ struct Converter<T>
         }, memberMetas);
 
         return cnvError;
+    }
+
+    static QJsonObject toJson(const T& value)
+    {
+        // Object to fill
+        QJsonObject jObject;
+
+        // Get member metadata tuple
+        constexpr auto memberMetas = QxJsonPrivate::getMemberMeta<T>();
+
+        // "Iterate" over each tuple element via std::apply and a fold expression
+        std::apply([&](auto&&... memberMeta) constexpr {
+            // Fold expression
+            ([&]{
+                // Meta
+                static constexpr auto mName = std::remove_reference<decltype(memberMeta)>::type::M_NAME;
+                constexpr QLatin1StringView mKey(mName.value);
+                using mType = typename std::remove_reference<decltype(memberMeta)>::type::M_TYPE;
+                auto& mRef = value.*(memberMeta.mPtr);
+
+                // Ignore if empty optional
+                if constexpr(json_optional<mType>)
+                {
+                    if(!mRef)
+                        return;
+                }
+
+                // Convert value and insert
+                if constexpr(json_override_convertible<T, mType, mName>)
+                    jObject.insert(mKey, QxJsonPrivate::overrideSerialize<T, mType, mName>(mRef));
+                else
+                    jObject.insert(mKey, QxJsonPrivate::standardSerialize<mType>(mRef));
+            }(), ...);
+        }, memberMetas);
+
+        return jObject;
     }
 };
 
@@ -473,7 +541,7 @@ struct Converter<T>
         if(!jValue.isArray())
         {
             return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<QJsonArray>()), Qx::JsonError::TypeMismatch)
-                   .withContext(QxJson::Array());
+            .withContext(QxJson::Array());
         }
 
         // Underlying Array
@@ -497,24 +565,45 @@ struct Converter<T>
 
         return Qx::JsonError();
     }
+
+    static QJsonArray toJson(const T& value)
+    {
+        // Array to fill
+        QJsonArray jArray;
+
+        // Convert all
+        for(const E& e : value)
+        {
+            // Ignore if empty optional
+            if constexpr(json_optional<E>)
+            {
+                if(!e)
+                    continue;
+            }
+
+            jArray.append(Converter<E>::toJson(e));
+        }
+
+        return jArray;
+    }
 };
 
 template<typename T>
     requires json_associative<T>
 struct Converter<T>
 {
+    using K = typename T::key_type;
+    using V = typename T::mapped_type;
+
     static Qx::JsonError fromJson(T& value, const QJsonValue& jValue)
     {
-        using K = typename T::key_type;
-        using V = typename T::mapped_type;
-
         // Reset buffer
         value.clear();
 
         if(!jValue.isArray())
         {
             return Qx::JsonError(QxJsonPrivate::ERR_CONV_TYPE.arg(QxJsonPrivate::typeString<QJsonArray>()), Qx::JsonError::TypeMismatch)
-                   .withContext(QxJson::Array());
+            .withContext(QxJson::Array());
         }
         // Underlying Array
         QJsonArray jArray = jValue.toArray();
@@ -537,6 +626,27 @@ struct Converter<T>
 
         return Qx::JsonError();
     }
+
+    static QJsonArray toJson(const T& value)
+    {
+        // Array to fill
+        QJsonArray jArray;
+
+        // Convert all
+        for(const V& v : value)
+        {
+            // Ignore if empty optional
+            if constexpr(json_optional<V>)
+            {
+                if(!v)
+                    continue;
+            }
+
+            jArray.append(Converter<V>::toJson(v));
+        }
+
+        return jArray;
+    }
 };
 
 template<typename T>
@@ -555,6 +665,12 @@ struct Converter<T>
 
         return je;
     }
+
+    static auto toJson(const T& value)
+    {
+        Q_ASSERT(value); // Optional must have value if this is reached
+        return Converter<O>::toJson(*value);
+    }
 };
 
 template<typename T>
@@ -568,6 +684,11 @@ struct Converter<T>
 
         value = static_cast<T>(jValue.toDouble());
         return Qx::JsonError();
+    }
+
+    static double toJson(const T& value)
+    {
+        return static_cast<double>(value);
     }
 };
 /*! @endcond */
@@ -585,21 +706,21 @@ concept json_root = QxJson::json_containing<T> ||
 //-Classes---------------------------------------------------------------------------------------------------------
 class QX_CORE_EXPORT QJsonParseErrorAdapter: public Qx::AbstractError<"QJsonParseError", 500>
 {
-//-Class Variables-------------------------------------------------------------------------------------
+    //-Class Variables-------------------------------------------------------------------------------------
 private:
     static inline const QString OFFSET_STR = u"Position: %1."_s;
 
-//-Instance Variables-------------------------------------------------------------------------------------
+    //-Instance Variables-------------------------------------------------------------------------------------
 private:
     const QJsonParseError& mErrorRef;
 
-//-Constructor---------------------------------------------------------------------------------------------
+    //-Constructor---------------------------------------------------------------------------------------------
 public:
     QJsonParseErrorAdapter(const QJsonParseError& e);
     QJsonParseErrorAdapter(QJsonParseErrorAdapter&&) = delete;
     QJsonParseErrorAdapter(const QJsonParseErrorAdapter&) = delete;
 
-//-Instance Functions-------------------------------------------------------------------------------------
+    //-Instance Functions-------------------------------------------------------------------------------------
 private:
     quint32 deriveValue() const override;
     QString derivePrimary() const override;
@@ -618,6 +739,13 @@ JsonError parseJson(T& parsed, const QJsonObject& obj)
 }
 
 template<typename T>
+    requires QxJson::json_struct<T>
+void serializeJson(QJsonObject& serialized, const T& struc)
+{
+    serialized = QxJson::Converter<T>::toJson(struc);
+}
+
+template<typename T>
     requires QxJson::json_containing<T>
 JsonError parseJson(T& parsed, const QJsonArray& array)
 {
@@ -625,6 +753,13 @@ JsonError parseJson(T& parsed, const QJsonArray& array)
     QJsonValue arrayAsValue(array);
 
     return QxJson::Converter<T>::fromJson(parsed, arrayAsValue);
+}
+
+template<typename T>
+    requires QxJson::json_containing<T>
+void serializeJson(QJsonArray& serialized, const T& container)
+{
+    serialized = QxJson::Converter<T>::toJson(container);
 }
 
 template<typename T>
@@ -652,20 +787,24 @@ JsonError parseJson(T& parsed, const QJsonDocument& doc)
 
 template<typename T>
     requires json_root<T>
+void serializeJson(QJsonDocument& serialized, const T& root)
+{
+    serialized = QJsonDocument(QxJson::Converter<T>::toJson(root));
+}
+
+template<typename T>
+    requires json_root<T>
 JsonError parseJson(T& parsed, QFile& file)
 {
     if(!file.exists())
         return JsonError(QxJsonPrivate::ERR_READ_FILE, JsonError::MissingFile).withContext(QxJson::File(file.fileName()));
 
-    // Close and re-open file if missing required mode
-    if(!file.isReadable())
-    {
-        if(file.isOpen())
-            file.close();
+    // Close and re-open file, if open, to ensure correct mode and start of file
+    if(file.isOpen())
+        file.close();
 
-        if(!file.open(QIODevice::ReadOnly))
-            return JsonError(QxJsonPrivate::ERR_READ_FILE, JsonError::InaccessibleFile).withContext(QxJson::File(file.fileName(), file.errorString()));
-    }
+    if(!file.open(QIODevice::ReadOnly))
+        return JsonError(QxJsonPrivate::ERR_READ_FILE, JsonError::InaccessibleFile).withContext(QxJson::File(file.fileName(), file.errorString()));
 
     // Close file when finished
     QScopeGuard fileGuard([&file]{ file.close(); });
@@ -693,11 +832,49 @@ JsonError parseJson(T& parsed, QFile& file)
 
 template<typename T>
     requires json_root<T>
+JsonError serializeJson(QFile& serialized, const T& root)
+{
+    // Close and re-open file, if open, to ensure correct mode and start of file
+    if(serialized.isOpen())
+        serialized.close();
+
+    if(!serialized.open(QIODevice::Truncate | QIODevice::WriteOnly))
+        return JsonError(QxJsonPrivate::ERR_WRITE_FILE, JsonError::InaccessibleFile).withContext(QxJson::File(serialized.fileName(), serialized.errorString()));
+
+    // Close file when finished
+    QScopeGuard fileGuard([&serialized]{ serialized.close(); });
+
+    // Create document
+    QJsonDocument jd;
+    serializeJson(jd, root);
+
+    // Write data
+    QByteArray jsonData = jd.toJson();
+    if(jsonData.isEmpty())
+        return JsonError(); // No-op
+
+    if(serialized.write(jsonData) != jsonData.size())
+        return JsonError(QxJsonPrivate::ERR_WRITE_FILE, JsonError::FileWriteError).withContext(QxJson::File(serialized.fileName(), serialized.errorString()));
+
+    return JsonError();
+}
+
+template<typename T>
+    requires json_root<T>
 JsonError parseJson(T& parsed, const QString& filePath)
 {
     QFile file(filePath);
 
     return parseJson(parsed, file);
+}
+
+template<typename T>
+    requires json_root<T>
+JsonError serializeJson(const QString& serializedPath, const T& root)
+{
+    QFile file(serializedPath);
+
+    return serializeJson(file, root);
 }
 
 QX_CORE_EXPORT QList<QJsonValue> findAllValues(const QJsonValue& rootValue, QStringView key);

--- a/lib/utility/include/qx/utility/qx-concepts.h
+++ b/lib/utility/include/qx/utility/qx-concepts.h
@@ -522,8 +522,8 @@ concept qassociative = specializes<T, QHash> ||
                        specializes<T, QMap>;
 
 template<typename T>
-concept qcollective = Qx::specializes<T, QList> ||
-                      Qx::specializes<T, QSet>;
+concept qcollective = specializes<T, QList> ||
+                      specializes<T, QSet>;
 
 }
 

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(qx_array)
 add_subdirectory(qx_freeindextracker)
 add_subdirectory(qx_integrity)
+add_subdirectory(qx_json)

--- a/tests/core/qx_json/CMakeLists.txt
+++ b/tests/core/qx_json/CMakeLists.txt
@@ -1,0 +1,8 @@
+include(OB/Test)
+
+ob_add_basic_standard_test(
+    TARGET_PREFIX "${TESTS_TARGET_PREFIX}"
+    LINKS
+        ${TESTS_COMMON_TARGET}
+        Qx::Core
+)

--- a/tests/core/qx_json/tst_qx_json.cpp
+++ b/tests/core/qx_json/tst_qx_json.cpp
@@ -1,0 +1,283 @@
+// Qt Includes
+#include <QtTest>
+
+// Qx Includes
+#include <qx/core/qx-json.h>
+#include <qx/core/qx-error.h>
+
+// Test Includes
+//#include <qx_test_common.h>
+
+// Some tests are incompatible with GCC < 11
+#if !defined(Q_CC_GNU) || defined(Q_CC_CLANG) || Q_CC_GNU >= 1100
+    #define COMPATIBLE_COMPILER
+#endif
+
+class tst_qx_json : public QObject
+{
+    Q_OBJECT
+
+public:
+    tst_qx_json();
+
+private slots:
+    // Init
+    // void initTestCase();
+    // void initTestCase_data();
+    // void cleanupTestCase();
+    // void init()
+    // void cleanup();
+
+    // Test cases
+    // void generateCheckum();
+    void full_declarative_suite();
+};
+
+//-Tools---------------------------------------------------------
+class CustomClass // Essentially just a struct, but tests custom Converter specialization
+{
+private:
+    bool ccb = false;
+    double ccd = 0.0;
+
+public:
+    CustomClass() {}
+    CustomClass(bool b, double d) :
+        ccb(b),
+        ccd(d)
+    {}
+
+    bool b() const { return ccb; }
+    double d() const { return ccd; }
+    void setB(bool b) { ccb = b; }
+    void setD(double d) { ccd = d; }
+    bool operator==(const CustomClass& other) const = default;
+};
+
+struct IntKeyable
+{
+    int key;
+    int value;
+
+    bool operator==(const IntKeyable& other) const = default;
+
+    // Basic inner struct macro
+    QX_JSON_STRUCT(key, value);
+};
+
+struct StringKeyable
+{
+    QString key;
+    int value;
+
+    bool operator==(const StringKeyable& other) const = default;
+
+    // Basic inner struct macro
+    QX_JSON_STRUCT(key, value);
+};
+
+struct OutsideTestee
+{
+    bool value;
+
+    bool operator==(const OutsideTestee& other) const = default;
+};
+QX_JSON_STRUCT_OUTSIDE(OutsideTestee, value);
+
+struct ExtendedOutsideTestee
+{
+    bool value;
+
+    bool operator==(const ExtendedOutsideTestee& other) const = default;
+};
+QX_JSON_STRUCT_OUTSIDE_X(ExtendedOutsideTestee, QX_JSON_MEMBER(value));
+
+struct Root
+{
+    // Basic types
+    bool b;
+    double d;
+    QString s;
+    QJsonArray ja;
+    QJsonObject jo;
+
+    // // Custom containers
+    QSet<QString> ss;
+    QList<std::optional<bool>> lob; // Optional in container
+
+    // Custom associative containers
+    QHash<int, IntKeyable> hii;
+    QMap<QString, StringKeyable> mss;
+
+    // Optional in object
+    std::optional<QString> osp; // Present optional
+    std::optional<QString> osm; // Missing optional
+
+    // Integers
+    int i;
+    long li;
+    short si;
+
+    // Custom object
+    CustomClass cc;
+
+    // Member with override conversion
+    QString ocs;
+
+    // Aliased member
+    double ad;
+
+    // Outside macro tests
+    OutsideTestee omt;
+    ExtendedOutsideTestee eomt;
+
+    // Extended inner struct macro
+    QX_JSON_STRUCT_X(
+        QX_JSON_MEMBER(b),
+        QX_JSON_MEMBER(d),
+        QX_JSON_MEMBER(s),
+        QX_JSON_MEMBER(ja),
+        QX_JSON_MEMBER(jo),
+        QX_JSON_MEMBER(ss),
+        QX_JSON_MEMBER(lob),
+        QX_JSON_MEMBER(hii),
+        QX_JSON_MEMBER(mss),
+        QX_JSON_MEMBER(osp),
+        QX_JSON_MEMBER(osm),
+        QX_JSON_MEMBER(i),
+        QX_JSON_MEMBER(li),
+        QX_JSON_MEMBER(si),
+        QX_JSON_MEMBER(cc),
+        QX_JSON_MEMBER(ocs),
+        QX_JSON_MEMBER_ALIASED(ad, "aliasedDouble"),
+        QX_JSON_MEMBER(omt),
+        QX_JSON_MEMBER(eomt)
+    );
+
+    bool operator==(const Root& other) const = default;
+};
+
+QX_JSON_MEMBER_OVERRIDE(Root, ocs,
+    static Qx::JsonError fromJson(QString& member, const QJsonValue& jv)
+    {
+        // Add prefix when parsing
+        member = "Prefix: " + jv.toString();
+        return Qx::JsonError();
+    }
+
+    static QString toJson(const QString& member)
+    {
+        // Remove prefix when serializing
+
+        return QString(member).remove("Prefix: ");
+    }
+)
+
+namespace QxJson
+{
+
+// Keygens
+template<>
+int keygen<int, IntKeyable>(const IntKeyable& value)
+{
+    return value.key;
+};
+
+template<>
+QString keygen<QString, StringKeyable>(const StringKeyable& value)
+{
+    return value.key;
+};
+
+
+template<>
+struct Converter<CustomClass>
+{
+    static Qx::JsonError fromJson(CustomClass& value, const QJsonValue& jValue)
+    {
+        const QString ERR_ACTION = u"Error converting Custom Class"_s;
+        if(!jValue.isObject())
+            return Qx::JsonError(ERR_ACTION, Qx::JsonError::TypeMismatch);
+
+        QJsonObject jo = jValue.toObject();
+
+        if(!jo.contains("ccb") || !jo.contains("ccd"))
+            return Qx::JsonError(ERR_ACTION, Qx::JsonError::MissingKey);
+
+        QJsonValue jvCcb = jo.value("ccb");
+        QJsonValue jvCcd = jo.value("ccd");
+
+        if(!jvCcb.isBool() || !jvCcd.isDouble())
+            return Qx::JsonError(ERR_ACTION, Qx::JsonError::TypeMismatch);
+
+        value.setB(jvCcb.toBool());
+        value.setD(jvCcd.toDouble());
+
+        return Qx::JsonError();
+    }
+
+    static QJsonObject toJson(const CustomClass& value)
+    {
+        // Use value to return a valid JSON type (i.e. qjson_type concept)
+        return {{"ccb", value.b()}, {"ccd", value.d()}};
+    }
+};
+}
+
+// Setup
+tst_qx_json::tst_qx_json() {}
+
+// Cases
+void tst_qx_json::full_declarative_suite()
+{
+#ifdef COMPATIBLE_COMPILER // JSON-tied structs crash GCC until version 11 (12?)
+    // Populate the very complex root
+    Root rOut{
+        .b = true,
+        .d = 4.0,
+        .s = "string",
+        .ja = {true, "2", 3},
+        .jo = {{"key1", 1.0}, {"key2", "2"}},
+        .ss = {"setOne", "setTwo"},
+        .lob = {true, std::nullopt, false},
+        .hii = {{1, {.key = 1, .value = 1}}}, // One value to keep Root comparable since QHash iteration order is undefined
+        .mss = {{"1", {.key = "1", .value = 1}}, {"2", {.key = "2", .value = 2}}},
+        .osp = "present_optional",
+        .osm = std::nullopt,
+        .i = 10,
+        .li = 20,
+        .si = 30,
+        .cc = CustomClass(true, 4.0),
+        .ocs = "Prefix: OriginalString",
+        .ad = 17.4,
+        .omt = {.value = true},
+        .eomt = {.value = false}
+    };
+
+    // Test string path overload, which tests all other overloads recursively
+    QTemporaryDir td;
+    QString filePath = td.filePath("full_declarative_suite.json");
+
+    // Serialize
+    Qx::JsonError serializeError = Qx::serializeJson(filePath, rOut);
+    QVERIFY2(!serializeError, qPrintable("Error serializing root! " + Qx::Error(serializeError).toString()));
+
+    /* Adjust for nullopt in array, should be ignored when serialized so we need to remove it from the
+     * struct before comparing against the result
+     */
+    rOut.lob.removeAt(1);
+
+    // Parse back file
+    Root rIn;
+    Qx::JsonError parseError = Qx::parseJson(rIn, filePath);
+    QVERIFY2(!parseError, qPrintable("Error parsing root! " + Qx::Error(parseError).toString()));
+
+    // Ensure process is lossless
+    QCOMPARE(rIn, rOut);    
+#else
+    QSKIP("GCC < 11 suffers an ICE from the compilation of declarative Qx JSON");
+#endif
+}
+
+QTEST_APPLESS_MAIN(tst_qx_json)
+#include "tst_qx_json.moc"


### PR DESCRIPTION
Can now do full-cycle serialization/parsing of JSON data via the declarative system in a *lossless fashion

*Some containers like QHash or QMap will enforce different ordering than is present in the original JSON data, and QJsonObject itself stores its keys as a QMap.